### PR TITLE
feat(firebase_ui_auth): Add "Go Back" button to EmailLinkSignInView

### DIFF
--- a/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
@@ -83,6 +83,14 @@ class _EmailLinkSignInViewState extends State<EmailLinkSignInView> {
               ),
             ],
             const SizedBox(height: 8),
+            UniversalButton(
+              text: l.goBackButtonLabel,
+              variant: ButtonVariant.text,
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            const SizedBox(height: 8),
             if (state is AuthFailed) ErrorText(exception: state.exception),
           ],
         );

--- a/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
@@ -39,6 +39,8 @@ class EmailLinkSignInView extends StatefulWidget {
 
 class _EmailLinkSignInViewState extends State<EmailLinkSignInView> {
   final emailCtrl = TextEditingController();
+  late final canPop = Navigator.canPop(context);
+
   @override
   Widget build(BuildContext context) {
     final l = FirebaseUILocalizations.labelsOf(context);
@@ -82,7 +84,7 @@ class _EmailLinkSignInViewState extends State<EmailLinkSignInView> {
                 },
               ),
             ],
-            if (Navigator.canPop(context)) ...[
+            if (canPop) ...[
               const SizedBox(height: 8),
               UniversalButton(
                 text: l.goBackButtonLabel,

--- a/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
@@ -82,14 +82,16 @@ class _EmailLinkSignInViewState extends State<EmailLinkSignInView> {
                 },
               ),
             ],
-            const SizedBox(height: 8),
-            UniversalButton(
-              text: l.goBackButtonLabel,
-              variant: ButtonVariant.text,
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
+            if (Navigator.canPop(context)) ...[
+              const SizedBox(height: 8),
+              UniversalButton(
+                text: l.goBackButtonLabel,
+                variant: ButtonVariant.text,
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
             const SizedBox(height: 8),
             if (state is AuthFailed) ErrorText(exception: state.exception),
           ],

--- a/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
@@ -1,10 +1,13 @@
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
-import '../flows/email_link_flow_test.dart';
 import '../test_utils.dart';
 
 void main() {
@@ -20,14 +23,19 @@ void main() {
       url: 'https://example.com',
     );
     emailLinkProvider = EmailLinkAuthProvider(
-        actionCodeSettings: actionCodeSettings, dynamicLinks: dynamicLinks);
+      actionCodeSettings: actionCodeSettings,
+      dynamicLinks: dynamicLinks,
+    );
   });
 
   /// If EmailLinkSignInView is the root view, there should be
   /// no option to go back.
   testWidgets('no go back option if root view', (tester) async {
     await tester.pumpWidget(TestMaterialApp(
-      child: EmailLinkSignInView(provider: emailLinkProvider, auth: auth),
+      child: EmailLinkSignInView(
+        provider: emailLinkProvider,
+        auth: auth,
+      ),
     ));
 
     final button = find.text(labels.goBackButtonLabel);

--- a/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 import '../test_utils.dart';
 
@@ -45,23 +45,25 @@ void main() {
   /// If EmailLinkSignInView is pushed from another view, there
   /// should be a button allowing a user to go back.
   testWidgets('show go back option if not root', (tester) async {
-    await tester.pumpWidget(TestMaterialApp(
+    await tester.pumpWidget(
+      TestMaterialApp(
         child: Builder(
-            builder: (context) => TextButton(
-                child: const Text("Push"),
-                onPressed: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => Scaffold(
-                        body: EmailLinkSignInView(
-                            provider: emailLinkProvider, auth: auth),
-                      ),
-                    ),
-                  ),
+          builder: (context) => TextButton(
+            child: const Text("Push"),
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => Scaffold(
+                  body: EmailLinkSignInView(
+                      provider: emailLinkProvider, auth: auth),
                 ),
               ),
             ),
-          );
+          ),
+        ),
+      ),
+    );
+
     await tester.tap(find.textContaining("Push"));
     await tester.pumpAndSettle();
     final button = find.text(labels.goBackButtonLabel);

--- a/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
@@ -56,7 +56,12 @@ void main() {
                         body: EmailLinkSignInView(
                             provider: emailLinkProvider, auth: auth),
                       ),
-                    ))))));
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
     await tester.tap(find.textContaining("Push"));
     await tester.pumpAndSettle();
     final button = find.text(labels.goBackButtonLabel);

--- a/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
@@ -1,0 +1,57 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+
+import '../flows/email_link_flow_test.dart';
+import '../test_utils.dart';
+
+void main() {
+  const labels = DefaultLocalizations();
+  late MockAuth auth;
+  late MockDynamicLinks dynamicLinks;
+  late EmailLinkAuthProvider emailLinkProvider;
+
+  setUp(() {
+    auth = MockAuth();
+    dynamicLinks = MockDynamicLinks();
+    final actionCodeSettings = ActionCodeSettings(
+      url: 'https://example.com',
+    );
+    emailLinkProvider = EmailLinkAuthProvider(
+        actionCodeSettings: actionCodeSettings, dynamicLinks: dynamicLinks);
+  });
+
+  /// If EmailLinkSignInView is the root view, there should be
+  /// no option to go back.
+  testWidgets('no go back option if root view', (tester) async {
+    await tester.pumpWidget(TestMaterialApp(
+      child: EmailLinkSignInView(provider: emailLinkProvider, auth: auth),
+    ));
+
+    final button = find.text(labels.goBackButtonLabel);
+    expect(button, findsNothing);
+  });
+
+  /// If EmailLinkSignInView is pushed from another view, there
+  /// should be a button allowing a user to go back.
+  testWidgets('show go back option if not root', (tester) async {
+    await tester.pumpWidget(TestMaterialApp(
+        child: Builder(
+            builder: (context) => TextButton(
+                child: const Text("Push"),
+                onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => Scaffold(
+                        body: EmailLinkSignInView(
+                            provider: emailLinkProvider, auth: auth),
+                      ),
+                    ))))));
+    await tester.tap(find.textContaining("Push"));
+    await tester.pumpAndSettle();
+    final button = find.text(labels.goBackButtonLabel);
+    expect(button, findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Description

This PR adds a "Go back" button to EmailLinkSignInView. Other views and screens in firebase_ui_auth have
a similar button already, but EmailLinkSignInView does not, so users can get stuck if they got there by mistake,
mistyped their email address, etc. This button code was copied from SMSCodeInputScreen, so it should be
consistent with other auth flows in the package.

## Related Issues

Fixes #81

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->

[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/contributing.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
