### PR TITLE
fix(ui_auth): Pass correct AuthAction to the footerBuilder

### DIFF
--- a/packages/firebase_ui_auth/lib/src/views/login_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/login_view.dart
@@ -242,7 +242,7 @@ class _LoginViewState extends State<LoginView> {
           if (widget.footerBuilder != null)
             widget.footerBuilder!(
               context,
-              widget.action,
+              _action,
             ),
         ],
       ),

--- a/packages/firebase_ui_auth/test/src/views/login_view_test.dart
+++ b/packages/firebase_ui_auth/test/src/views/login_view_test.dart
@@ -1,0 +1,84 @@
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  group("$LoginView", () {
+    testWidgets(
+      'rebuilds the footer when the $AuthAction changes',
+      (tester) async {
+        const signInKey = ValueKey("Sign in");
+        const registerKey = ValueKey("Register");
+
+        const widgetSignIn = SizedBox(key: signInKey);
+        const widgetRegister = SizedBox(key: registerKey);
+
+        final view = TestMaterialApp(
+          child: LoginView(
+            providers: [EmailAuthProvider()],
+            auth: MockAuth(),
+            action: AuthAction.signIn,
+            showAuthActionSwitch: true,
+            footerBuilder: (context, action) {
+              switch (action) {
+                case AuthAction.signIn:
+                  return widgetSignIn;
+                case AuthAction.signUp:
+                  return widgetRegister;
+                default:
+                  return const SizedBox();
+              }
+            },
+          ),
+        );
+        await tester.pumpWidget(view);
+
+        expect(find.byKey(signInKey), findsOneWidget);
+        expect(find.byKey(registerKey), findsNothing);
+
+        await _tapOnRegisterActionText(tester);
+
+        expect(find.byKey(signInKey), findsNothing);
+        expect(find.byKey(registerKey), findsOneWidget);
+      },
+    );
+  });
+}
+
+/// Taps on the Register text in the action switch of the [LoginView].
+///
+/// We have to do this because the [WidgetTester] API does not enable the search
+/// for a particular TextSpan.
+/// See https://stackoverflow.com/a/60247474/19586032 for more details.
+Future<void> _tapOnRegisterActionText(WidgetTester tester) async {
+  final actionSwitchRichText = find
+      .byWidgetPredicate(
+        (widget) =>
+            widget is RichText &&
+            widget.text.toPlainText().contains("Register"),
+      )
+      .evaluate()
+      .first
+      .renderObject! as RenderParagraph;
+
+  actionSwitchRichText.text.visitChildren((InlineSpan span) {
+    if (span is! TextSpan) return true;
+
+    span.visitChildren((InlineSpan span) {
+      if (span is! TextSpan) return true;
+
+      if (span.text != 'Register') return true;
+
+      (span.recognizer! as TapGestureRecognizer).onTap!();
+      return false;
+    });
+
+    return true;
+  });
+
+  await tester.pumpAndSettle();
+}

--- a/packages/firebase_ui_auth/test/src/views/login_view_test.dart
+++ b/packages/firebase_ui_auth/test/src/views/login_view_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
## Description

This change is needed to rebuild the footer when the action changes (for example when the user click on the header auth action switch)

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/contributing.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
