### PR TITLE
feat(ui_auth): add display name screen when user register

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,14 @@
+# How to cut a new release of Firebase UI
+
+1. Switch to `main` branch locally.
+2. Run `git pull origin main`.
+3. Run `git pull --tags` to make sure all tags are fetched.
+4. Create new branch with the signature "release/[year]-[month]-[day]".
+5. Run `melos version --no-git-tag-version` to automatically version packages and update Changelogs.
+6. Run `melos publish` to dry run and confirm all packages are publishable.
+7. After successful dry run, commit all changes with the signature "chore(release): prepare for release".
+8. Run `git push origin [RELEASE BRANCH NAME]` & open pull request for review on GitHub.
+9. After successful review and merge of the pull request, switch to `main` branch locally, & run `git pull origin main`.
+10. Run `melos publish --no-dry-run --git-tag-version` to now publish to Pub.dev.
+11. Run `git push --tags` to push tags to repository.
+12. Ping @kevinthecheung to get the changelog in Firebase releases.

--- a/packages/firebase_ui_auth/example/lib/main.dart
+++ b/packages/firebase_ui_auth/example/lib/main.dart
@@ -84,7 +84,7 @@ class FirebaseAuthUIExample extends StatelessWidget {
     );
 
     final mfaAction = AuthStateChangeAction<MFARequired>(
-      (context, state) async {
+          (context, state) async {
         final nav = Navigator.of(context);
 
         await startMFAVerification(
@@ -131,11 +131,29 @@ class FirebaseAuthUIExample extends StatelessWidget {
                   _ => null,
                 };
 
+
                 switch (user) {
                   case User(emailVerified: true):
                     Navigator.pushReplacementNamed(context, '/profile');
                   case User(emailVerified: false, email: final String _):
                     Navigator.pushNamed(context, '/verify-email');
+                  case User(displayName: null):
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (context) {
+                        return Scaffold(
+                          appBar: AppBar(
+                            title: const Text('What is your name?'),
+                          ),
+                          body: const Padding(
+                            padding: EdgeInsets.all(16.0),
+                            child: Column(children: [
+                              SizedBox(height: 10),
+                              EditableUserDisplayName(),
+                            ]),
+                          ),
+                        );
+                      }),
+                    );
                 }
               }),
               mfaAction,
@@ -215,7 +233,7 @@ class FirebaseAuthUIExample extends StatelessWidget {
         },
         '/sms': (context) {
           final arguments = ModalRoute.of(context)?.settings.arguments
-              as Map<String, dynamic>?;
+          as Map<String, dynamic>?;
 
           return SMSCodeInputScreen(
             actions: [
@@ -231,7 +249,7 @@ class FirebaseAuthUIExample extends StatelessWidget {
         },
         '/forgot-password': (context) {
           final arguments = ModalRoute.of(context)?.settings.arguments
-              as Map<String, dynamic>?;
+          as Map<String, dynamic>?;
 
           return ForgotPasswordScreen(
             email: arguments?['email'],

--- a/packages/firebase_ui_auth/example/lib/main.dart
+++ b/packages/firebase_ui_auth/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart'
     hide PhoneAuthProvider, EmailAuthProvider;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:firebase_ui_auth/src/screens/display_name_screen.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_oauth_apple/firebase_ui_oauth_apple.dart';
 import 'package:firebase_ui_oauth_facebook/firebase_ui_oauth_facebook.dart';
@@ -137,23 +138,6 @@ class FirebaseAuthUIExample extends StatelessWidget {
                     Navigator.pushReplacementNamed(context, '/profile');
                   case User(emailVerified: false, email: final String _):
                     Navigator.pushNamed(context, '/verify-email');
-                  case User(displayName: null):
-                    Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) {
-                        return Scaffold(
-                          appBar: AppBar(
-                            title: const Text('What is your name?'),
-                          ),
-                          body: const Padding(
-                            padding: EdgeInsets.all(16.0),
-                            child: Column(children: [
-                              SizedBox(height: 10),
-                              EditableUserDisplayName(),
-                            ]),
-                          ),
-                        );
-                      }),
-                    );
                 }
               }),
               mfaAction,
@@ -204,7 +188,7 @@ class FirebaseAuthUIExample extends StatelessWidget {
             actionCodeSettings: actionCodeSettings,
             actions: [
               EmailVerifiedAction(() {
-                Navigator.pushReplacementNamed(context, '/profile');
+                Navigator.pushReplacementNamed(context, '/display-name');
               }),
               AuthCancelledAction((context) {
                 FirebaseUIAuth.signOut(context: context);
@@ -249,13 +233,22 @@ class FirebaseAuthUIExample extends StatelessWidget {
         },
         '/forgot-password': (context) {
           final arguments = ModalRoute.of(context)?.settings.arguments
-          as Map<String, dynamic>?;
+              as Map<String, dynamic>?;
 
           return ForgotPasswordScreen(
             email: arguments?['email'],
             headerMaxExtent: 200,
             headerBuilder: headerIcon(Icons.lock),
             sideBuilder: sideIcon(Icons.lock),
+          );
+        },
+        '/display-name': (context) {
+          return DisplayNameScreen(
+            actions: [
+              DisplayNameChangedAction((context, displayName) {
+                Navigator.pushReplacementNamed(context, '/profile');
+              }),
+            ],
           );
         },
         '/email-link-sign-in': (context) {

--- a/packages/firebase_ui_auth/lib/src/actions.dart
+++ b/packages/firebase_ui_auth/lib/src/actions.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:flutter/material.dart';
 
 /// An abstract class that all actions implement.
 /// The following actions are available:
@@ -82,6 +82,18 @@ class AuthCancelledAction extends FirebaseUIAction {
 
   /// {@macro ui.auth.actions.cancel}
   AuthCancelledAction(this.callback);
+}
+
+/// {@template ui.auth.actions.display_name_changed_action}
+/// An action that is called when the user's display name changes.
+/// You can capture the new display name using this action.
+/// {@endtemplate}
+class DisplayNameChangedAction extends FirebaseUIAction {
+  /// A callback that is being called when the user's display name changes.
+  final void Function(BuildContext context, String newDisplayName) callback;
+
+  /// {@macro ui.auth.actions.display_name_changed_action}
+  DisplayNameChangedAction(this.callback);
 }
 
 /// {@template ui.auth.actions.flutter_fire_ui_actions}

--- a/packages/firebase_ui_auth/lib/src/screens/display_name_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/display_name_screen.dart
@@ -1,0 +1,180 @@
+// Copyright 2022, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
+import 'package:flutter/material.dart' hide Title;
+import 'package:flutter/scheduler.dart';
+
+import '../widgets/editable_sign_user_display_name.dart';
+import 'internal/responsive_page.dart';
+
+/// An action that is being called when sign up was successfully.
+class DisplayNameAction extends FirebaseUIAction {
+  final VoidCallback callback;
+
+  DisplayNameAction(this.callback);
+}
+
+/// {@template ui.auth.screens.display_name_screen}
+/// A screen where users can edit their display name.
+/// {@endtemplate}
+class DisplayNameScreen extends StatelessWidget {
+  /// {@macro ui.auth.auth_controller.auth}
+  final FirebaseAuth? auth;
+
+  /// {@macro ui.auth.screens.responsive_page.header_builder}
+  final HeaderBuilder? headerBuilder;
+
+  /// DisplayNameScreen could invoke these actions:
+  ///
+  /// * [AuthCancelledAction]
+  /// * [EmailVerifiedAction]
+  ///
+  /// ```dart
+  /// DisplayNameScreen(
+  ///   actions: [
+  ///     EmailVerified(() {
+  ///       Navigator.pushReplacementNamed(context, '/profile');
+  ///     }),
+  ///     Cancel((context) {
+  ///       Navigator.of(context).pop();
+  ///     }),
+  ///   ],
+  /// );
+  /// ```
+  final List<FirebaseUIAction> actions;
+
+  /// {@macro ui.auth.screens.responsive_page.header_max_extent}
+  final double? headerMaxExtent;
+
+  /// {@macro ui.auth.screens.responsive_page.side_builder}
+  final SideBuilder? sideBuilder;
+
+  /// {@macro ui.auth.screens.responsive_page.desktop_layout_direction}
+  final TextDirection? desktopLayoutDirection;
+
+  /// {@macro ui.auth.screens.responsive_page.breakpoint}
+  final double breakpoint;
+
+  /// A configuration object used to construct a dynamic link.
+  final ActionCodeSettings? actionCodeSettings;
+
+  /// {@macro ui.auth.screens.email_verification_screen}
+  const DisplayNameScreen({
+    super.key,
+    this.auth,
+    this.actions = const [],
+    this.headerBuilder,
+    this.headerMaxExtent,
+    this.sideBuilder,
+    this.desktopLayoutDirection,
+    this.breakpoint = 500,
+    this.actionCodeSettings,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FirebaseUIActions(
+      actions: actions,
+      child: UniversalScaffold(
+        body: ResponsivePage(
+          breakpoint: breakpoint,
+          desktopLayoutDirection: desktopLayoutDirection,
+          headerBuilder: headerBuilder,
+          headerMaxExtent: headerMaxExtent,
+          sideBuilder: sideBuilder,
+          maxWidth: 1200,
+          contentFlex: 2,
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: _DisplayNameScreenContent(
+              auth: auth,
+              actionCodeSettings: actionCodeSettings,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// This allows a value of type T or T?
+/// to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become
+/// non-nullable can still be used with `!` and `?`
+/// to support older versions of the API as well.
+T? _ambiguate<T>(T? value) => value;
+
+class _DisplayNameScreenContent extends StatefulWidget {
+  /// {@macro ui.auth.auth_controller.auth}
+  final FirebaseAuth? auth;
+  final ActionCodeSettings? actionCodeSettings;
+
+  const _DisplayNameScreenContent({
+    required this.auth,
+    required this.actionCodeSettings,
+  });
+
+  @override
+  State<_DisplayNameScreenContent> createState() =>
+      __DisplayNameScreenContentState();
+}
+
+class __DisplayNameScreenContentState extends State<_DisplayNameScreenContent> {
+  late final controller = EmailVerificationController(auth);
+
+  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
+
+  User get user => auth.currentUser!;
+  bool isLoading = false;
+
+  @override
+  void initState() {
+    _ambiguate(SchedulerBinding.instance)!
+        .addPostFrameCallback(_sendEmailVerification);
+    super.initState();
+  }
+
+  void _sendEmailVerification(_) {
+    controller
+      ..addListener(() {
+        setState(() {});
+
+        if (state == EmailVerificationState.verified) {
+          final action = FirebaseUIAction.ofType<DisplayNameAction>(context);
+          action?.callback();
+        }
+      })
+      ..sendVerificationEmail(
+        Theme.of(context).platform,
+        widget.actionCodeSettings,
+      );
+  }
+
+  EmailVerificationState get state => controller.state;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = FirebaseUILocalizations.labelsOf(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Align(
+          child: Text(
+            l.name,
+            style: Theme.of(context).textTheme.headline6,
+          ),
+        ),
+        const SizedBox(height: 32),
+        EditableSignUserDisplayName(auth: auth),
+      ],
+    );
+  }
+}

--- a/packages/firebase_ui_auth/lib/src/widgets/editable_sign_user_display_name.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/editable_sign_user_display_name.dart
@@ -1,0 +1,150 @@
+// Copyright 2022, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../../firebase_ui_auth.dart';
+import 'internal/subtitle.dart';
+
+class EditableSignUserDisplayName extends StatefulWidget {
+  /// {@macro ui.auth.auth_controller.auth}
+  final FirebaseAuth? auth;
+
+  /// {@macro ui.auth.widgets.editable_user_display_name}
+  const EditableSignUserDisplayName({
+    super.key,
+    this.auth,
+  });
+
+  @override
+  // ignore: library_private_types_in_public_api
+  _EditableSignUserDisplayNameState createState() =>
+      _EditableSignUserDisplayNameState();
+}
+
+class _EditableSignUserDisplayNameState
+    extends State<EditableSignUserDisplayName> {
+  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
+
+  String? get displayName => auth.currentUser?.displayName;
+
+  late final ctrl = TextEditingController(text: displayName ?? '');
+
+  late bool _editing = displayName == null;
+  bool _isLoading = false;
+
+  void _onEdit() {
+    setState(() {
+      _editing = true;
+    });
+  }
+
+  Future<void> _finishEditing() async {
+    try {
+      if (displayName == ctrl.text) return;
+
+      setState(() {
+        _isLoading = true;
+      });
+
+      await auth.currentUser?.updateDisplayName(ctrl.text);
+      await auth.currentUser?.reload();
+      final action = FirebaseUIAction.ofType<DisplayNameChangedAction>(context);
+      action?.callback(context, ctrl.text);
+    } finally {
+      setState(() {
+        _editing = false;
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l = FirebaseUILocalizations.labelsOf(context);
+    final isCupertino = CupertinoUserInterfaceLevel.maybeOf(context) != null;
+
+    late Widget iconButton;
+
+    if (isCupertino) {
+      iconButton = Transform.translate(
+        offset: Offset(0, _editing ? -12 : 0),
+        child: CupertinoButton(
+          onPressed: _editing ? _finishEditing : _onEdit,
+          child: Icon(
+            _editing ? CupertinoIcons.check_mark_circled : CupertinoIcons.pen,
+          ),
+        ),
+      );
+    } else {
+      iconButton = IconButton(
+        icon: Icon(_editing ? Icons.check : Icons.edit),
+        color: theme.colorScheme.secondary,
+        onPressed: _editing ? _finishEditing : _onEdit,
+      );
+    }
+
+    if (!_editing) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 5.5),
+        child: IntrinsicWidth(
+          child: Row(
+            children: [
+              Subtitle(text: displayName ?? 'Unknown'),
+              iconButton,
+            ],
+          ),
+        ),
+      );
+    }
+
+    late Widget textField;
+
+    if (isCupertino) {
+      textField = Padding(
+        padding: const EdgeInsets.symmetric(vertical: 17.5),
+        child: CupertinoTextField(
+          autofocus: true,
+          controller: ctrl,
+          placeholder: l.name,
+          onSubmitted: (_) => _finishEditing(),
+        ),
+      );
+    } else {
+      textField = TextField(
+        autofocus: true,
+        controller: ctrl,
+        decoration: InputDecoration(hintText: l.name, labelText: l.name),
+        onSubmitted: (_) => _finishEditing(),
+      );
+    }
+
+    return Row(
+      children: [
+        Expanded(child: textField),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 50,
+          height: 32,
+          child: Stack(
+            children: [
+              if (_isLoading)
+                const LoadingIndicator(size: 24, borderWidth: 1)
+              else
+                Align(
+                  alignment: Alignment.topLeft,
+                  child: iconButton,
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Description

This PR enhances the ```SignInScreen``` widget by adding a new feature. When the `displayName` property of the user is found to be `null`, the app will now navigate the user to a screen titled "What is your name?" where they can input or edit their display name. This feature provides a more user-friendly.

## Related Issues

This is based on [Discussed in 69](https://github.com/firebase/FirebaseUI-Flutter/discussions/69) and [Issue 76 ](https://github.com/firebase/FirebaseUI-Flutter/issues/76)for enhancement 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/contributing.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
