### PR TITLE
[firebase_ui_oauth] Fix provider auth listener late init exception

### DIFF
--- a/packages/firebase_ui_oauth/lib/src/oauth_provider_button_base.dart
+++ b/packages/firebase_ui_oauth/lib/src/oauth_provider_button_base.dart
@@ -339,6 +339,10 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
 
   @override
   void onError(Object error) {
+    setState(() {
+      isLoading = false;
+    });
+
     try {
       defaultOnAuthError(provider, error);
     } on Exception catch (err) {

--- a/packages/firebase_ui_oauth/lib/src/oauth_provider_button_base.dart
+++ b/packages/firebase_ui_oauth/lib/src/oauth_provider_button_base.dart
@@ -142,6 +142,9 @@ class OAuthProviderButtonBase extends StatefulWidget {
 
 class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
     implements OAuthListener {
+  @override
+  late final OAuthProvider provider = widget.provider;
+
   double get _height => widget.size + widget._padding * 2;
   late bool isLoading = widget.isLoading;
 
@@ -149,8 +152,8 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
   void initState() {
     super.initState();
 
-    widget.provider.auth = widget.auth ?? FirebaseAuth.instance;
-    widget.provider.authListener = this;
+    provider.auth = widget.auth ?? FirebaseAuth.instance;
+    provider.authListener = this;
   }
 
   void _signIn() {
@@ -360,9 +363,6 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
 
     super.didUpdateWidget(oldWidget);
   }
-
-  @override
-  OAuthProvider get provider => widget.provider;
 }
 
 class _ButtonContent extends StatelessWidget {


### PR DESCRIPTION
## Description

It's possible for the provider to get recreated when the button rebuilds. Since the authListener is set in `initState` it only happens the first time. Any auth methods called on the provider after the second rebuild will throw a late initialization error since the authListener will not be set. This PR adds code to store the provider in the state so that it cannot get reset externally.

I also set the `isLoading` to false in the `onError` callback otherwise the button will get stuck in a loading state when there is an error.

## Related Issues

I don't see one

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/contributing.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
