### PR TITLE
feat(ui_auth): add a way to customize ErrorText message

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/error_text.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/error_text.dart
@@ -37,6 +37,28 @@ String? localizedErrorText(
 /// A widget which displays error text for a given Firebase error code.
 /// {@endtemplate}
 class ErrorText extends StatelessWidget {
+  /// A way to customize localized error messages.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// ErrorText.localizeError = (BuildContext context, FirebaseAuthException e) {
+  ///   return switch (e.code) {
+  ///     'user-not-found' => 'Please create an account first.',
+  ///     'credential-already-in-use' => 'This email is already in use.',
+  ///     _ => 'Oh no! Something went wrong.'
+  ///   }
+  /// }
+  static String Function(
+    BuildContext context,
+    FirebaseAuthException exception,
+  )? localizeError;
+
+  /// A way to customize the widget that is used across the library to show
+  /// error hints. By default a localized text is used with a color set to
+  /// [ColorScheme.error] under [MaterialApp] and
+  /// [CupertinoColors.destructiveRed] under [CupertinoApp].
+  static Widget Function(BuildContext context, String message)? builder;
+
   /// An exception that contains error details.
   /// Often this is a [FirebaseAuthException].
   final Exception exception;
@@ -70,12 +92,16 @@ class ErrorText extends StatelessWidget {
     }
 
     if (exception is FirebaseAuthException) {
-      final e = exception as FirebaseAuthException;
-      final code = e.code;
-      final newText = localizedErrorText(code, l) ?? e.message;
+      if (localizeError != null) {
+        text = localizeError!(context, exception as FirebaseAuthException);
+      } else {
+        final e = exception as FirebaseAuthException;
+        final code = e.code;
+        final newText = localizedErrorText(code, l) ?? e.message;
 
-      if (newText != null) {
-        text = newText;
+        if (newText != null) {
+          text = newText;
+        }
       }
     }
 

--- a/packages/firebase_ui_auth/test/widgets/error_text_test.dart
+++ b/packages/firebase_ui_auth/test/widgets/error_text_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';

--- a/packages/firebase_ui_auth/test/widgets/error_text_test.dart
+++ b/packages/firebase_ui_auth/test/widgets/error_text_test.dart
@@ -1,0 +1,59 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final exception = FirebaseAuthException(
+    code: 'invalid-email',
+    message: 'The email address is badly formatted.',
+  );
+
+  group('$ErrorText', () {
+    tearDown(() {
+      ErrorText.localizeError = null;
+    });
+
+    testWidgets('uses localizations', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ErrorText(exception: exception),
+          localizationsDelegates: [
+            FirebaseUILocalizations.delegate,
+          ],
+        ),
+      );
+      expect(
+        find.text('The email address is badly formatted.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('allows to override error text', (tester) async {
+      String localizeError(
+        BuildContext context,
+        FirebaseAuthException exception,
+      ) {
+        expect(exception.code, 'invalid-email');
+        return 'Custom error text';
+      }
+
+      ErrorText.localizeError = localizeError;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ErrorText(exception: exception),
+          localizationsDelegates: [
+            FirebaseUILocalizations.delegate,
+          ],
+        ),
+      );
+
+      expect(
+        find.text('Custom error text'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/contributing.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
