### PR TITLE
fix(ui_localizations): loading Traditional Chinese

### DIFF
--- a/packages/firebase_ui_localizations/lib/src/all_languages.dart
+++ b/packages/firebase_ui_localizations/lib/src/all_languages.dart
@@ -50,8 +50,10 @@ final Set<String> kSupportedLanguages = {
   'zh', // Chinese
 };
 
-FirebaseUILocalizationLabels getFirebaseUITranslation(Locale useLocale,
-    [Locale? defaultLocale]) {
+FirebaseUILocalizationLabels getFirebaseUITranslation(
+  Locale useLocale, [
+  Locale? defaultLocale,
+]) {
   final Locale locale;
   if (kSupportedLanguages.contains(useLocale.languageCode)) {
     locale = useLocale;

--- a/packages/firebase_ui_localizations/lib/src/all_languages.dart
+++ b/packages/firebase_ui_localizations/lib/src/all_languages.dart
@@ -1,52 +1,118 @@
 // Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import "./default_localizations.dart";
+import 'dart:ui';
 
+import "./default_localizations.dart";
+import 'lang/ar.dart';
+import 'lang/de.dart';
+import 'lang/en.dart';
 import 'lang/es.dart';
 import 'lang/es_419.dart';
-import 'lang/ko.dart';
+import 'lang/fr.dart';
+import 'lang/he.dart';
+import 'lang/hi.dart';
 import 'lang/hu.dart';
 import 'lang/id.dart';
-import 'lang/pt.dart';
-import 'lang/he.dart';
-import 'lang/de.dart';
 import 'lang/it.dart';
-import 'lang/zh.dart';
-import 'lang/zh_tw.dart';
-import 'lang/uk.dart';
-import 'lang/th.dart';
-import 'lang/ar.dart';
-import 'lang/tr.dart';
+import 'lang/ja.dart';
+import 'lang/ko.dart';
 import 'lang/nl.dart';
 import 'lang/pl.dart';
-import 'lang/en.dart';
-import 'lang/ja.dart';
-import 'lang/hi.dart';
+import 'lang/pt.dart';
 import 'lang/ru.dart';
-import 'lang/fr.dart';
+import 'lang/th.dart';
+import 'lang/tr.dart';
+import 'lang/uk.dart';
+import 'lang/zh.dart';
+import 'lang/zh_tw.dart';
 
-final localizations = <String, FirebaseUILocalizationLabels>{
-  'es': const EsLocalizations(),
-  'es_419': const Es419Localizations(),
-  'ko': const KoLocalizations(),
-  'hu': const HuLocalizations(),
-  'id': const IdLocalizations(),
-  'pt': const PtLocalizations(),
-  'he': const HeLocalizations(),
-  'de': const DeLocalizations(),
-  'it': const ItLocalizations(),
-  'zh': const ZhLocalizations(),
-  'zh_tw': const ZhTWLocalizations(),
-  'uk': const UkLocalizations(),
-  'th': const ThLocalizations(),
-  'ar': const ArLocalizations(),
-  'tr': const TrLocalizations(),
-  'nl': const NlLocalizations(),
-  'pl': const PlLocalizations(),
-  'en': const EnLocalizations(),
-  'ja': const JaLocalizations(),
-  'hi': const HiLocalizations(),
-  'ru': const RuLocalizations(),
-  'fr': const FrLocalizations(),
+final Set<String> kSupportedLanguages = {
+  'ar', // Arabic
+  'de', // German
+  'en', // English
+  'es', // Spanish Castilian
+  'fr', // French
+  'he', // Hebrew
+  'hi', // Hindi
+  'hu', // Hungarian
+  'id', // Indonesian
+  'it', // Italian
+  'ja', // Japanese
+  'ko', // Korean
+  'nl', // Dutch Flemish
+  'pl', // Polish
+  'pt', // Portuguese
+  'ru', // Russian
+  'th', // Thai
+  'tr', // Turkish
+  'uk', // Ukrainian
+  'zh', // Chinese
 };
+
+FirebaseUILocalizationLabels getFirebaseUITranslation(Locale useLocale, [Locale? defaultLocale]) {
+  final Locale locale;
+  if (kSupportedLanguages.contains(useLocale.languageCode)) {
+    locale = useLocale;
+  } else {
+    locale = defaultLocale ?? useLocale;
+  }
+
+  switch (locale.languageCode) {
+    case 'ar':
+      return const ArLocalizations();
+    case 'de':
+      return const DeLocalizations();
+    case 'en':
+      return const EnLocalizations();
+    case 'es':
+      switch (locale.countryCode) {
+        case '419':
+          return const Es419Localizations();
+      }
+      return const EsLocalizations();
+    case 'fr':
+      return const FrLocalizations();
+    case 'he':
+      return const HeLocalizations();
+    case 'hi':
+      return const HiLocalizations();
+    case 'hu':
+      return const HuLocalizations();
+    case 'id':
+      return const IdLocalizations();
+    case 'it':
+      return const ItLocalizations();
+    case 'ja':
+      return const JaLocalizations();
+    case 'ko':
+      return const KoLocalizations();
+    case 'nl':
+      return const NlLocalizations();
+    case 'pl':
+      return const PlLocalizations();
+    case 'pt':
+      return const PtLocalizations();
+    case 'ru':
+      return const RuLocalizations();
+    case 'th':
+      return const ThLocalizations();
+    case 'tr':
+      return const TrLocalizations();
+    case 'uk':
+      return const UkLocalizations();
+    case 'zh':
+      switch (locale.scriptCode) {
+        case 'Hant':
+          return const ZhTWLocalizations();
+      }
+      switch (locale.countryCode) {
+        case 'HK':
+        case 'TW':
+          return const ZhTWLocalizations();
+      }
+      return const ZhLocalizations();
+  }
+
+  throw ('getTranslationLabels() called for unsupported locale "$locale"');
+}

--- a/packages/firebase_ui_localizations/lib/src/all_languages.dart
+++ b/packages/firebase_ui_localizations/lib/src/all_languages.dart
@@ -50,7 +50,8 @@ final Set<String> kSupportedLanguages = {
   'zh', // Chinese
 };
 
-FirebaseUILocalizationLabels getFirebaseUITranslation(Locale useLocale, [Locale? defaultLocale]) {
+FirebaseUILocalizationLabels getFirebaseUITranslation(Locale useLocale,
+    [Locale? defaultLocale]) {
   final Locale locale;
   if (kSupportedLanguages.contains(useLocale.languageCode)) {
     locale = useLocale;

--- a/packages/firebase_ui_localizations/lib/src/l10n.dart
+++ b/packages/firebase_ui_localizations/lib/src/l10n.dart
@@ -36,8 +36,8 @@ class FirebaseUILocalizations<T extends FirebaseUILocalizationLabels> {
       return l;
     }
 
-    final defaultLocalizations = localizations[kDefaultLocale.languageCode]!;
-    return FirebaseUILocalizations(kDefaultLocale, defaultLocalizations);
+    final defaultTranslation = getFirebaseUITranslation(kDefaultLocale);
+    return FirebaseUILocalizations(kDefaultLocale, defaultTranslation);
   }
 
   /// Returns localization labels.
@@ -47,14 +47,12 @@ class FirebaseUILocalizations<T extends FirebaseUILocalizationLabels> {
 
   /// Localization delegate that could be provided to the
   /// [MaterialApp.localizationsDelegates].
-  static FirebaseUILocalizationDelegate delegate =
-      const FirebaseUILocalizationDelegate();
+  static FirebaseUILocalizationDelegate delegate = const FirebaseUILocalizationDelegate();
 
   /// Should be used to override labels provided by the library.
   ///
   /// See [FirebaseUILocalizationLabels].
-  static FirebaseUILocalizationDelegate
-      withDefaultOverrides<T extends DefaultLocalizations>(T overrides) {
+  static FirebaseUILocalizationDelegate withDefaultOverrides<T extends DefaultLocalizations>(T overrides) {
     return FirebaseUILocalizationDelegate<T>(overrides);
   }
 }
@@ -74,32 +72,18 @@ class FirebaseUILocalizationDelegate<T extends FirebaseUILocalizationLabels>
   ]);
 
   @override
-  bool isSupported(Locale locale) {
-    return _forceSupportAllLocales ||
-        localizations.keys.contains(locale.languageCode);
-  }
+  bool isSupported(Locale locale) => _forceSupportAllLocales || kSupportedLanguages.contains(locale.languageCode);
 
   @override
   Future<FirebaseUILocalizations> load(Locale locale) {
-    late FirebaseUILocalizationLabels labels;
+    final translation = getFirebaseUITranslation(locale, kDefaultLocale);
 
-    final key = locale.languageCode;
-    final fullKey = '${key}_${locale.countryCode.toString()}';
-
-    if (localizations.containsKey(fullKey)) {
-      labels = localizations[fullKey]!;
-    } else if (localizations.containsKey(key)) {
-      labels = localizations[key]!;
-    } else {
-      labels = localizations[kDefaultLocale.languageCode]!;
-    }
-
-    final l = FirebaseUILocalizations(
+    final localizations = FirebaseUILocalizations(
       locale,
-      overrides ?? labels,
+      overrides ?? translation,
     );
 
-    return SynchronousFuture<FirebaseUILocalizations>(l);
+    return SynchronousFuture<FirebaseUILocalizations>(localizations);
   }
 
   @override

--- a/packages/firebase_ui_localizations/lib/src/l10n.dart
+++ b/packages/firebase_ui_localizations/lib/src/l10n.dart
@@ -47,12 +47,14 @@ class FirebaseUILocalizations<T extends FirebaseUILocalizationLabels> {
 
   /// Localization delegate that could be provided to the
   /// [MaterialApp.localizationsDelegates].
-  static FirebaseUILocalizationDelegate delegate = const FirebaseUILocalizationDelegate();
+  static FirebaseUILocalizationDelegate delegate =
+      const FirebaseUILocalizationDelegate();
 
   /// Should be used to override labels provided by the library.
   ///
   /// See [FirebaseUILocalizationLabels].
-  static FirebaseUILocalizationDelegate withDefaultOverrides<T extends DefaultLocalizations>(T overrides) {
+  static FirebaseUILocalizationDelegate
+      withDefaultOverrides<T extends DefaultLocalizations>(T overrides) {
     return FirebaseUILocalizationDelegate<T>(overrides);
   }
 }
@@ -72,7 +74,9 @@ class FirebaseUILocalizationDelegate<T extends FirebaseUILocalizationLabels>
   ]);
 
   @override
-  bool isSupported(Locale locale) => _forceSupportAllLocales || kSupportedLanguages.contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      _forceSupportAllLocales ||
+      kSupportedLanguages.contains(locale.languageCode);
 
   @override
   Future<FirebaseUILocalizations> load(Locale locale) {

--- a/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
+++ b/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
@@ -17,8 +17,9 @@ Future<void> main() async {
   group(
     'FirebaseUILocalization loads the appropriate Chinese translation',
     () {
-      localizedText(BuildContext context) =>
-          FirebaseUILocalizations.labelsOf(context).signInWithPhoneButtonText;
+      localizedText(BuildContext context) {
+        return FirebaseUILocalizations.labelsOf(context).signInWithPhoneButtonText;
+      }
 
       setUp(() async {
         delegate = const FirebaseUILocalizationDelegate();
@@ -71,8 +72,7 @@ Future<void> main() async {
   group(
     'Localization override',
     () {
-      localizedText(BuildContext context) =>
-          FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
+      localizedText(BuildContext context) => FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
 
       test(
         'Overrides the DefaultLocalizations',
@@ -163,9 +163,7 @@ class TestMaterialApp extends StatelessWidget {
       localizationsDelegates: [
         GlobalMaterialLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
-        localizationsOverride == null
-            ? FirebaseUILocalizations.delegate
-            : localizationsOverride!,
+        localizationsOverride == null ? FirebaseUILocalizations.delegate : localizationsOverride!,
       ],
       home: Builder(
         builder: (context) => Text(

--- a/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
+++ b/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
@@ -1,0 +1,91 @@
+// Copyright 2022, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:firebase_ui_localizations/src/lang/zh_tw.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+  const localeTW = Locale('zh', 'TW');
+  const localeZh = Locale('zh');
+  const localeHant = Locale.fromSubtags(
+    languageCode: 'zh',
+    scriptCode: 'Hant',
+  );
+
+  late FirebaseUILocalizationDelegate delegate;
+
+  group(
+    'FirebaseUILocalization loads the appropriate Chinese translation',
+    () {
+      setUp(() async {
+        delegate = const FirebaseUILocalizationDelegate();
+      });
+
+      test(
+        'Loads the correct translation with the language tag "${localeTW.toLanguageTag()}"',
+        () async {
+          final localizations = await delegate.load(localeTW);
+          expect(localizations.labels.signInWithPhoneButtonText, '使用電話號碼登入');
+        },
+      );
+
+      test(
+        'Loads the correct translation with the language tag "${localeZh.toLanguageTag()}"',
+        () async {
+          final localizations = await delegate.load(localeZh);
+          expect(localizations.labels.signInWithPhoneButtonText, '使用电话号码登录');
+        },
+      );
+
+      test(
+        'Use the ZhTWLocalizations translation if only the language and script code are provided for the language tag "${localeHant.toLanguageTag()}"',
+        () async {
+          final localizations = await delegate.load(localeHant);
+          expect(localizations.labels.signInWithPhoneButtonText, '使用電話號碼登入');
+        },
+      );
+    },
+  );
+
+  group(
+    'Localization override',
+    () {
+      test(
+        'Overrides the DefaultLocalizations',
+        () async {
+          final localizations = await const FirebaseUILocalizationDelegate(
+            DefaultLocalizationsOverrides(),
+          ).load(localeTW);
+          expect(localizations.labels.verifyEmailTitle, 'Overwritten verifyEmailTitle');
+        },
+      );
+
+      test(
+        'Overrides the DefaultLocalizations',
+        () async {
+          final localizations = await const FirebaseUILocalizationDelegate(
+            ZhTWLocalizationsOverrides(),
+          ).load(localeTW);
+          expect(localizations.labels.verifyEmailTitle, '覆寫標題');
+        },
+      );
+    },
+  );
+}
+
+class DefaultLocalizationsOverrides extends DefaultLocalizations {
+  const DefaultLocalizationsOverrides();
+
+  @override
+  String get verifyEmailTitle => 'Overwritten verifyEmailTitle';
+}
+
+class ZhTWLocalizationsOverrides extends ZhTWLocalizations {
+  const ZhTWLocalizationsOverrides();
+
+  @override
+  String get verifyEmailTitle => '覆寫標題';
+}

--- a/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
+++ b/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
@@ -18,7 +18,8 @@ Future<void> main() async {
     'FirebaseUILocalization loads the appropriate Chinese translation',
     () {
       localizedText(BuildContext context) {
-        return FirebaseUILocalizations.labelsOf(context).signInWithPhoneButtonText;
+        return FirebaseUILocalizations.labelsOf(context)
+            .signInWithPhoneButtonText;
       }
 
       setUp(() async {
@@ -72,7 +73,8 @@ Future<void> main() async {
   group(
     'Localization override',
     () {
-      localizedText(BuildContext context) => FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
+      localizedText(BuildContext context) =>
+          FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
 
       test(
         'Overrides the DefaultLocalizations',
@@ -163,7 +165,9 @@ class TestMaterialApp extends StatelessWidget {
       localizationsDelegates: [
         GlobalMaterialLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
-        localizationsOverride == null ? FirebaseUILocalizations.delegate : localizationsOverride!,
+        localizationsOverride == null
+            ? FirebaseUILocalizations.delegate
+            : localizationsOverride!,
       ],
       home: Builder(
         builder: (context) => Text(

--- a/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
+++ b/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
@@ -8,12 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main() async {
-  const localeTW = Locale('zh', 'TW');
   const localeZh = Locale('zh');
-  const localeHant = Locale.fromSubtags(
-    languageCode: 'zh',
-    scriptCode: 'Hant',
-  );
+  const localeTW = Locale('zh', 'TW');
 
   late FirebaseUILocalizationDelegate delegate;
 
@@ -25,14 +21,6 @@ Future<void> main() async {
       });
 
       test(
-        'Loads the correct translation with the language tag "${localeTW.toLanguageTag()}"',
-        () async {
-          final localizations = await delegate.load(localeTW);
-          expect(localizations.labels.signInWithPhoneButtonText, '使用電話號碼登入');
-        },
-      );
-
-      test(
         'Loads the correct translation with the language tag "${localeZh.toLanguageTag()}"',
         () async {
           final localizations = await delegate.load(localeZh);
@@ -41,9 +29,9 @@ Future<void> main() async {
       );
 
       test(
-        'Use the ZhTWLocalizations translation if only the language and script code are provided for the language tag "${localeHant.toLanguageTag()}"',
+        'Loads the correct translation with the language tag "${localeTW.toLanguageTag()}"',
         () async {
-          final localizations = await delegate.load(localeHant);
+          final localizations = await delegate.load(localeTW);
           expect(localizations.labels.signInWithPhoneButtonText, '使用電話號碼登入');
         },
       );
@@ -59,7 +47,7 @@ Future<void> main() async {
           final localizations = await const FirebaseUILocalizationDelegate(
             DefaultLocalizationsOverrides(),
           ).load(localeTW);
-          expect(localizations.labels.verifyEmailTitle, 'Overwritten verifyEmailTitle');
+          expect(localizations.labels.verifyEmailTitle, 'Overwritten');
         },
       );
 
@@ -80,7 +68,7 @@ class DefaultLocalizationsOverrides extends DefaultLocalizations {
   const DefaultLocalizationsOverrides();
 
   @override
-  String get verifyEmailTitle => 'Overwritten verifyEmailTitle';
+  String get verifyEmailTitle => 'Overwritten';
 }
 
 class ZhTWLocalizationsOverrides extends ZhTWLocalizations {

--- a/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
+++ b/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
@@ -17,9 +17,9 @@ Future<void> main() async {
   group(
     'FirebaseUILocalization loads the appropriate Chinese translation',
     () {
-      localizedText(BuildContext context) {
-        return FirebaseUILocalizations.labelsOf(context)
-            .signInWithPhoneButtonText;
+      localizeText(BuildContext context) {
+        final labels = FirebaseUILocalizations.labelsOf(context);
+        return labels.signInWithPhoneButtonText;
       }
 
       setUp(() async {
@@ -40,7 +40,7 @@ Future<void> main() async {
           await tester.pumpWidget(
             TestMaterialApp(
               locale: localeZh,
-              localizeText: localizedText,
+              localizeText: localizeText,
             ),
           );
           expect(find.text('使用电话号码登录'), findsOneWidget);
@@ -61,7 +61,7 @@ Future<void> main() async {
           await tester.pumpWidget(
             TestMaterialApp(
               locale: localeTW,
-              localizeText: localizedText,
+              localizeText: localizeText,
             ),
           );
           expect(find.text('使用電話號碼登入'), findsOneWidget);
@@ -73,8 +73,9 @@ Future<void> main() async {
   group(
     'Localization override',
     () {
-      localizedText(BuildContext context) =>
-          FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
+      localizeText(BuildContext context) {
+        return FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
+      }
 
       test(
         'Overrides the DefaultLocalizations',
@@ -95,7 +96,7 @@ Future<void> main() async {
               localizationsOverride: const FirebaseUILocalizationDelegate(
                 DefaultLocalizationsOverrides(),
               ),
-              localizeText: localizedText,
+              localizeText: localizeText,
             ),
           );
           expect(find.text('Overwritten'), findsOneWidget);
@@ -121,7 +122,7 @@ Future<void> main() async {
               localizationsOverride: const FirebaseUILocalizationDelegate(
                 ZhTWLocalizationsOverrides(),
               ),
-              localizeText: localizedText,
+              localizeText: localizeText,
             ),
           );
           expect(find.text('覆寫標題'), findsOneWidget);

--- a/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
+++ b/packages/firebase_ui_localizations/test/firebase_ui_localizations_test.dart
@@ -17,7 +17,8 @@ Future<void> main() async {
   group(
     'FirebaseUILocalization loads the appropriate Chinese translation',
     () {
-      localizedText(BuildContext context) => FirebaseUILocalizations.labelsOf(context).signInWithPhoneButtonText;
+      localizedText(BuildContext context) =>
+          FirebaseUILocalizations.labelsOf(context).signInWithPhoneButtonText;
 
       setUp(() async {
         delegate = const FirebaseUILocalizationDelegate();
@@ -37,7 +38,7 @@ Future<void> main() async {
           await tester.pumpWidget(
             TestMaterialApp(
               locale: localeZh,
-              localizedText: localizedText,
+              localizeText: localizedText,
             ),
           );
           expect(find.text('使用电话号码登录'), findsOneWidget);
@@ -58,7 +59,7 @@ Future<void> main() async {
           await tester.pumpWidget(
             TestMaterialApp(
               locale: localeTW,
-              localizedText: localizedText,
+              localizeText: localizedText,
             ),
           );
           expect(find.text('使用電話號碼登入'), findsOneWidget);
@@ -70,7 +71,8 @@ Future<void> main() async {
   group(
     'Localization override',
     () {
-      localizedText(BuildContext context) => FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
+      localizedText(BuildContext context) =>
+          FirebaseUILocalizations.labelsOf(context).verifyEmailTitle;
 
       test(
         'Overrides the DefaultLocalizations',
@@ -91,7 +93,7 @@ Future<void> main() async {
               localizationsOverride: const FirebaseUILocalizationDelegate(
                 DefaultLocalizationsOverrides(),
               ),
-              localizedText: localizedText,
+              localizeText: localizedText,
             ),
           );
           expect(find.text('Overwritten'), findsOneWidget);
@@ -117,7 +119,7 @@ Future<void> main() async {
               localizationsOverride: const FirebaseUILocalizationDelegate(
                 ZhTWLocalizationsOverrides(),
               ),
-              localizedText: localizedText,
+              localizeText: localizedText,
             ),
           );
           expect(find.text('覆寫標題'), findsOneWidget);
@@ -144,28 +146,32 @@ class ZhTWLocalizationsOverrides extends ZhTWLocalizations {
 class TestMaterialApp extends StatelessWidget {
   final Locale locale;
   final LocalizationsDelegate? localizationsOverride;
-  final String Function(BuildContext context) localizedText;
+  final String Function(BuildContext context) localizeText;
 
   const TestMaterialApp({
     super.key,
     required this.locale,
     this.localizationsOverride,
-    required this.localizedText,
+    required this.localizeText,
   });
 
   @override
-  Widget build(BuildContext context) => MaterialApp(
-        supportedLocales: const [localeZh, localeTW],
-        locale: locale,
-        localizationsDelegates: [
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          localizationsOverride == null ? FirebaseUILocalizations.delegate : localizationsOverride!,
-        ],
-        home: Builder(
-          builder: (context) => Text(
-            localizedText.call(context),
-          ),
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      supportedLocales: const [localeZh, localeTW],
+      locale: locale,
+      localizationsDelegates: [
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        localizationsOverride == null
+            ? FirebaseUILocalizations.delegate
+            : localizationsOverride!,
+      ],
+      home: Builder(
+        builder: (context) => Text(
+          localizeText.call(context),
         ),
-      );
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Description

I found that the `firebase_ui_localizations` package includes a translation for Taiwan (`ZhTWLocalizations`), but has not been used appropriately. So I follow the same approach of how the `flutter_localizations` package gets the appropriate translation and how to fallback when the `scriptCode` or `countryCode` is not defined.

## Related Issues

Closes #33 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/contributing.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
