### PR TITLE
docs: Update README.md for AuthUI to fix links to docs pages

### DIFF
--- a/packages/firebase_ui_auth/README.md
+++ b/packages/firebase_ui_auth/README.md
@@ -84,16 +84,16 @@ fonts:
 
 ## Docs
 
-Find relevant documentation [here](https://github.com/firebase/FirebaseUI-Flutter/tree/main/docs/firebase_ui_auth)
+Find relevant documentation [here](https://github.com/firebase/FirebaseUI-Flutter/tree/main/docs/firebase-ui-auth)
 
-- [Getting started](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase_ui_auth/README.md)
+- [Getting started](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase-ui-auth/README.md)
 - Auth providers.
-  - [Email auth provider](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase_ui_auth/providers/email.md) – sign in using email and password.
-  - [Email verification](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase_ui_auth/providers/email-verification.md) - verify email.
-  - [Email link sign in](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase_ui_auth/providers/email-link.md) - sign in using a link sent to email.
-  - [Phone auth provider](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase_ui_auth/providers/phone.md) - sign in using phone number.
-  - [Universal email sign in](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase_ui_auth/providers/universal-email-sign-in.md) - resolve connected providers based on email and sign in using one of those.
-  - [OAuth](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase_ui_auth/providers/oauth.md) - sign in using Apple, Google, Facebook or Twitter.
+  - [Email auth provider](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase-ui-auth/providers/email.md) – sign in using email and password.
+  - [Email verification](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase-ui-auth/providers/email-verification.md) - verify email.
+  - [Email link sign in](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase-ui-auth/providers/email-link.md) - sign in using a link sent to email.
+  - [Phone auth provider](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase-ui-auth/providers/phone.md) - sign in using phone number.
+  - [Universal email sign in](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase-ui-auth/providers/universal-email-sign-in.md) - resolve connected providers based on email and sign in using one of those.
+  - [OAuth](https://github.com/firebase/FirebaseUI-Flutter/blob/main/docs/firebase-ui-auth/providers/oauth.md) - sign in using Apple, Google, Facebook or Twitter.
 
 ## Issues and feedback
 


### PR DESCRIPTION
The docs are use dashes in `firebase-ui-auth`, rather than underscores that the code does (`firebase_ui_auth`).

## Description

The docs links on https://pub.dev/packages/firebase_ui_auth don't work, because they link to the wrong URLs. This PR fixes the URLs.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
