### PR TITLE
fix(ui_auth): deprecate functionality that uses fetchSignInMethodsForEmail

### DIFF
--- a/packages/firebase_ui_auth/lib/src/auth_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/auth_flow.dart
@@ -27,7 +27,6 @@ class AuthCancelledException implements Exception {
 /// - [EmailLinkFlow]
 /// - [OAuthFlow]
 /// - [PhoneAuthFlow]
-/// - [UniversalEmailSignInFlow]
 ///
 /// See [AuthFlowBuilder] docs to learn how to wire up the auth flow with the
 /// widget tree.

--- a/packages/firebase_ui_auth/lib/src/flows/universal_email_sign_in_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/flows/universal_email_sign_in_flow.dart
@@ -6,6 +6,10 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 /// A controller interface of the [UniversalEmailSignInFlow].
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 abstract class UniversalEmailSignInController extends AuthController {
   /// {@template ui.auth.auth_controller.find_providers_for_email}
   /// Finds providers that can be used to sign in with a provided email.
@@ -20,6 +24,10 @@ abstract class UniversalEmailSignInController extends AuthController {
 /// An auth flow that resolves providers that are accosicatied with the given
 /// email.
 /// {@endtemplate}
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 class UniversalEmailSignInFlow extends AuthFlow<UniversalEmailSignInProvider>
     implements UniversalEmailSignInController, UniversalEmailSignInListener {
   // {@macro ui.auth.flows.universal_email_sign_in_flow}

--- a/packages/firebase_ui_auth/lib/src/providers/auth_provider.dart
+++ b/packages/firebase_ui_auth/lib/src/providers/auth_provider.dart
@@ -21,15 +21,6 @@ void defaultOnAuthError(AuthProvider provider, Object error) {
     return;
   }
 
-  if (error.code == 'account-exists-with-different-credential') {
-    final email = error.email;
-    if (email == null) {
-      throw error;
-    }
-
-    provider.findProvidersForEmail(email, error.credential);
-  }
-
   throw error;
 }
 
@@ -39,7 +30,6 @@ void defaultOnAuthError(AuthProvider provider, Object error) {
 /// - [EmailAuthListener]
 /// - [EmailLinkAuthListener]
 /// - [PhoneAuthListener]
-/// - [UniversalEmailSignInListener]
 abstract class AuthListener {
   /// Current [AuthProvider] that is being used to authenticate the user.
   AuthProvider get provider;
@@ -64,9 +54,17 @@ abstract class AuthListener {
   void onCredentialLinked(AuthCredential credential);
 
   /// Called before an attempt to fetch available providers for the email.
+  @Deprecated(
+    'Email enumeration protection is on by default.'
+    'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+  )
   void onBeforeProvidersForEmailFetch();
 
   /// Called when available providers for the email were successfully fetched.
+  @Deprecated(
+    'Email enumeration protection is on by default.'
+    'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+  )
   void onDifferentProvidersFound(
     String email,
     List<String> providers,
@@ -139,6 +137,10 @@ abstract class AuthProvider<T extends AuthListener, K extends AuthCredential> {
   }
 
   /// Fetches available providers for the given [email].
+  @Deprecated(
+    'Email enumeration protection is on by default.'
+    'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+  )
   void findProvidersForEmail(
     String email, [
     AuthCredential? credential,

--- a/packages/firebase_ui_auth/lib/src/providers/universal_email_sign_in_provider.dart
+++ b/packages/firebase_ui_auth/lib/src/providers/universal_email_sign_in_provider.dart
@@ -7,6 +7,10 @@ import 'package:flutter/foundation.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 /// A [UniversalEmailSignInFlow] lifecycle listener.
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 abstract class UniversalEmailSignInListener extends AuthListener {
   @override
   void onBeforeProvidersForEmailFetch();
@@ -21,6 +25,10 @@ abstract class UniversalEmailSignInListener extends AuthListener {
 
 /// A provider that resolves available authentication methods for a given
 /// email.
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 class UniversalEmailSignInProvider
     extends AuthProvider<UniversalEmailSignInListener, AuthCredential> {
   @override

--- a/packages/firebase_ui_auth/lib/src/screens/universal_email_sign_in_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/universal_email_sign_in_screen.dart
@@ -9,6 +9,10 @@ import '../widgets/internal/universal_page_route.dart';
 import 'internal/multi_provider_screen.dart';
 
 /// A screen that allows to resolve previously used providers for a given email.
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 class UniversalEmailSignInScreen extends MultiProviderScreen {
   /// A callback that is being called when providers fetch request completed.
   final ProvidersFoundCallback? onProvidersFound;

--- a/packages/firebase_ui_auth/lib/src/views/find_providers_for_email_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/find_providers_for_email_view.dart
@@ -11,6 +11,10 @@ import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import '../widgets/internal/title.dart';
 
 /// A callback that is being called when providers fetch request is completed.
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 typedef ProvidersFoundCallback = void Function(
   String email,
   List<String> providers,
@@ -19,6 +23,10 @@ typedef ProvidersFoundCallback = void Function(
 /// {@template ui.auth.views.find_providers_for_email_view}
 /// A view that could be used to build a custom [UniversalEmailSignInScreen].
 /// {@endtemplate}
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 class FindProvidersForEmailView extends StatefulWidget {
   final ProvidersFoundCallback? onProvidersFound;
 
@@ -37,6 +45,10 @@ class FindProvidersForEmailView extends StatefulWidget {
       _FindProvidersForEmailViewState();
 }
 
+@Deprecated(
+  'Email enumeration protection is on by default.'
+  'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
+)
 class _FindProvidersForEmailViewState extends State<FindProvidersForEmailView> {
   final formKey = GlobalKey<FormState>();
   final emailCtrl = TextEditingController();

--- a/packages/firebase_ui_auth/lib/src/widgets/auth_flow_builder.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/auth_flow_builder.dart
@@ -56,7 +56,6 @@ typedef StateTransitionListener<T extends AuthController> = void Function(
 /// * [EmailLinkFlow]
 /// * [OAuthFlow]
 /// * [PhoneAuthFlow]
-/// * [UniversalEmailSignInFlow].
 ///
 /// An example of how to build a custom email sign up form using
 /// [AuthFlowBuilder]:
@@ -138,7 +137,6 @@ class AuthFlowBuilder<T extends AuthController> extends StatefulWidget {
   /// The following providers are optional to provide:
   /// * [EmailAuthController]
   /// * [PhoneAuthController]
-  /// * [UniversalEmailSignInController]
   final AuthProvider? provider;
 
   /// An optional instance of the [AuthFlow].
@@ -228,7 +226,10 @@ class _AuthFlowBuilderState<T extends AuthController>
         return EmailAuthProvider();
       case PhoneAuthController:
         return PhoneAuthProvider();
+
+      // ignore: deprecated_member_use_from_same_package
       case UniversalEmailSignInController:
+        // ignore: deprecated_member_use_from_same_package
         return UniversalEmailSignInProvider();
       default:
         throw Exception("Can't create $T provider");
@@ -268,7 +269,9 @@ class _AuthFlowBuilderState<T extends AuthController>
         action: widget.action,
         auth: widget.auth,
       );
+      // ignore: deprecated_member_use_from_same_package
     } else if (provider is UniversalEmailSignInProvider) {
+      // ignore: deprecated_member_use_from_same_package
       return UniversalEmailSignInFlow(
         provider: provider,
         action: widget.action,

--- a/packages/firebase_ui_auth/test/flows/universal_email_sign_in_flow_test.dart
+++ b/packages/firebase_ui_auth/test/flows/universal_email_sign_in_flow_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';

--- a/tests/integration_test/firebase_ui_auth/universal_email_sign_in_screen_test.dart
+++ b/tests/integration_test/firebase_ui_auth/universal_email_sign_in_screen_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'package:firebase_auth/firebase_auth.dart'
     hide EmailAuthProvider, PhoneAuthProvider;
 import 'package:firebase_core/firebase_core.dart';


### PR DESCRIPTION
## Description

Email enumeration protection is on by default for new projects. This breaks UniversalEmailSignInScreen and other Firebase UI Auth APIs that use fetchSignInMethodsForEmail under the hood.

Read more details here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection

## Related Issues

Closes #148

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
