### PR TITLE
chore: import firebase_auth as named

### DIFF
--- a/packages/firebase_ui_auth/lib/firebase_ui_auth.dart
+++ b/packages/firebase_ui_auth/lib/firebase_ui_auth.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 import 'package:flutter/widgets.dart';
@@ -138,16 +138,16 @@ class FirebaseUIAuth {
     _providers[resolvedApp] = configs;
 
     configs.whereType<OAuthProvider>().forEach((element) {
-      final auth = FirebaseAuth.instanceFor(app: resolvedApp);
+      final auth = fba.FirebaseAuth.instanceFor(app: resolvedApp);
       OAuthProviders.register(auth, element);
     });
   }
 
   static Future<void> signOut({
     BuildContext? context,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
   }) async {
-    final resolvedAuth = auth ?? FirebaseAuth.instance;
+    final resolvedAuth = auth ?? fba.FirebaseAuth.instance;
     await OAuthProviders.signOut(resolvedAuth);
     await resolvedAuth.signOut();
 

--- a/packages/firebase_ui_auth/lib/src/actions.dart
+++ b/packages/firebase_ui_auth/lib/src/actions.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -92,7 +92,7 @@ class AuthCancelledAction extends FirebaseUIAction {
 /// {@endtemplate}
 class AccountDeletedAction extends FirebaseUIAction {
   /// A callback that is being called when user has deleted their account.
-  final void Function(BuildContext context, User user) callback;
+  final void Function(BuildContext context, fba.User user) callback;
 
   /// {@macro ui.auth.actions.account_deleted}
   AccountDeletedAction(this.callback);

--- a/packages/firebase_ui_auth/lib/src/auth_controller.dart
+++ b/packages/firebase_ui_auth/lib/src/auth_controller.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 
 /// {@template ui.auth.auth_action}
@@ -58,7 +58,7 @@ abstract class AuthController {
   /// The [FirebaseAuth] instance used to perform authentication against.
   /// By default, [FirebaseAuth.instance] is used.
   /// {@endtemplate}
-  FirebaseAuth get auth;
+  fba.FirebaseAuth get auth;
 
   /// {@template ui.auth.auth_controller.reset}
   /// Resets the controller to initial state.

--- a/packages/firebase_ui_auth/lib/src/auth_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/auth_flow.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 /// An exception that is being thrown when user cancels the authentication
@@ -34,7 +34,7 @@ class AuthCancelledException implements Exception {
 class AuthFlow<T extends AuthProvider> extends ValueNotifier<AuthState>
     implements AuthController, AuthListener {
   @override
-  FirebaseAuth auth;
+  fba.FirebaseAuth auth;
 
   /// An initial auth state. Usually [Uninitialized], but varies for different
   /// auth flows.
@@ -96,20 +96,20 @@ class AuthFlow<T extends AuthProvider> extends ValueNotifier<AuthState>
     required T provider,
 
     /// {@macro ui.auth.auth_controller.auth}
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
 
     /// {@macro @macro ui.auth.auth_action}
     AuthAction? action,
-  })  : auth = auth ?? FirebaseAuth.instance,
+  })  : auth = auth ?? fba.FirebaseAuth.instance,
         _action = action,
         _provider = provider,
         super(initialState) {
     _provider.authListener = this;
-    _provider.auth = auth ?? FirebaseAuth.instance;
+    _provider.auth = auth ?? fba.FirebaseAuth.instance;
   }
 
   @override
-  void onCredentialReceived(AuthCredential credential) {
+  void onCredentialReceived(fba.AuthCredential credential) {
     value = CredentialReceived(credential);
   }
 
@@ -124,7 +124,7 @@ class AuthFlow<T extends AuthProvider> extends ValueNotifier<AuthState>
   }
 
   @override
-  void onCredentialLinked(AuthCredential credential) {
+  void onCredentialLinked(fba.AuthCredential credential) {
     value = CredentialLinked(credential, auth.currentUser!);
   }
 
@@ -132,7 +132,7 @@ class AuthFlow<T extends AuthProvider> extends ValueNotifier<AuthState>
   void onDifferentProvidersFound(
     String email,
     List<String> providers,
-    AuthCredential? credential,
+    fba.AuthCredential? credential,
   ) {
     value = DifferentSignInMethodsFound(
       email,
@@ -142,7 +142,7 @@ class AuthFlow<T extends AuthProvider> extends ValueNotifier<AuthState>
   }
 
   @override
-  void onSignedIn(UserCredential credential) {
+  void onSignedIn(fba.UserCredential credential) {
     if (credential.additionalUserInfo?.isNewUser ?? false) {
       value = UserCreated(credential);
     } else {
@@ -173,7 +173,7 @@ class AuthFlow<T extends AuthProvider> extends ValueNotifier<AuthState>
   }
 
   @override
-  void onMFARequired(MultiFactorResolver resolver) {
+  void onMFARequired(fba.MultiFactorResolver resolver) {
     value = MFARequired(resolver);
   }
 }

--- a/packages/firebase_ui_auth/lib/src/email_verification.dart
+++ b/packages/firebase_ui_auth/lib/src/email_verification.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:flutter/material.dart';
 
@@ -40,7 +40,7 @@ enum EmailVerificationState {
 class EmailVerificationController extends ValueNotifier<EmailVerificationState>
     with WidgetsBindingObserver {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth auth;
+  final fba.FirebaseAuth auth;
 
   EmailVerificationController(this.auth)
       : super(EmailVerificationState.unresolved) {
@@ -65,7 +65,7 @@ class EmailVerificationController extends ValueNotifier<EmailVerificationState>
   }
 
   /// An instance of user that is currently signed in.
-  User get user => auth.currentUser!;
+  fba.User get user => auth.currentUser!;
 
   /// Current [EmailVerificationState].
   EmailVerificationState get state => value;
@@ -98,7 +98,7 @@ class EmailVerificationController extends ValueNotifier<EmailVerificationState>
   /// Sends an email with a link to verify the user's email address.
   Future<void> sendVerificationEmail(
     TargetPlatform platform,
-    ActionCodeSettings? actionCodeSettings,
+    fba.ActionCodeSettings? actionCodeSettings,
   ) async {
     value = EmailVerificationState.sending;
     try {

--- a/packages/firebase_ui_auth/lib/src/flows/email_link_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/flows/email_link_flow.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -35,7 +35,7 @@ class EmailLinkFlow extends AuthFlow<EmailLinkAuthProvider>
   /// {@macro ui.auth.flows.email_link_flow}
   EmailLinkFlow({
     /// {@macro ui.auth.auth_controller.auth}
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
 
     /// {@macro ui.auth.auth_flow.ctor.provider}
     required EmailLinkAuthProvider provider,

--- a/packages/firebase_ui_auth/lib/src/flows/oauth_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/flows/oauth_flow.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/foundation.dart' show TargetPlatform;
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
@@ -27,7 +27,7 @@ class OAuthFlow extends AuthFlow<OAuthProvider>
     AuthAction? action,
 
     /// {@macro ui.auth.auth_controller.auth}
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
   }) : super(
           action: action,
           auth: auth,

--- a/packages/firebase_ui_auth/lib/src/flows/universal_email_sign_in_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/flows/universal_email_sign_in_flow.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 /// A controller interface of the [UniversalEmailSignInFlow].
@@ -36,7 +36,7 @@ class UniversalEmailSignInFlow extends AuthFlow<UniversalEmailSignInProvider>
     required UniversalEmailSignInProvider provider,
 
     /// {@macro ui.auth.auth_controller.auth}
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
 
     /// {@macro @macro ui.auth.auth_action}
     AuthAction? action,

--- a/packages/firebase_ui_auth/lib/src/mfa.dart
+++ b/packages/firebase_ui_auth/lib/src/mfa.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:firebase_auth/firebase_auth.dart' hide PhoneAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_auth/src/widgets/internal/universal_page_route.dart';
 import 'package:flutter/scheduler.dart';
@@ -17,13 +17,13 @@ typedef SMSCodeInputScreenBuilder = Widget Function(
   AuthAction action,
 );
 
-Future<UserCredential> startMFAVerification({
+Future<fba.UserCredential> startMFAVerification({
   required BuildContext context,
-  required MultiFactorResolver resolver,
-  FirebaseAuth? auth,
+  required fba.MultiFactorResolver resolver,
+  fba.FirebaseAuth? auth,
   SMSCodeInputScreenBuilder? smsCodeInputScreenBuilder,
 }) async {
-  if (resolver.hints.first is PhoneMultiFactorInfo) {
+  if (resolver.hints.first is fba.PhoneMultiFactorInfo) {
     return startPhoneMFAVerification(
       context: context,
       resolver: resolver,
@@ -34,22 +34,22 @@ Future<UserCredential> startMFAVerification({
   }
 }
 
-Future<UserCredential> startPhoneMFAVerification({
+Future<fba.UserCredential> startPhoneMFAVerification({
   required BuildContext context,
-  required MultiFactorResolver resolver,
-  FirebaseAuth? auth,
+  required fba.MultiFactorResolver resolver,
+  fba.FirebaseAuth? auth,
   SMSCodeInputScreenBuilder? smsCodeInputScreenBuilder,
 }) async {
   final session = resolver.session;
   final hint = resolver.hints.first;
-  final completer = Completer<UserCredential>();
+  final completer = Completer<fba.UserCredential>();
   final navigator = Navigator.of(context);
 
   final provider = PhoneAuthProvider();
-  provider.auth = auth ?? FirebaseAuth.instance;
+  provider.auth = auth ?? fba.FirebaseAuth.instance;
 
   final flow = PhoneAuthFlow(
-    auth: auth ?? FirebaseAuth.instance,
+    auth: auth ?? fba.FirebaseAuth.instance,
     action: AuthAction.none,
     provider: PhoneAuthProvider(),
   );
@@ -60,8 +60,8 @@ Future<UserCredential> startPhoneMFAVerification({
 
   final actions = [
     AuthStateChangeAction<CredentialReceived>((context, inner) {
-      final cred = inner.credential as PhoneAuthCredential;
-      final assertion = PhoneMultiFactorGenerator.getAssertion(cred);
+      final cred = inner.credential as fba.PhoneAuthCredential;
+      final assertion = fba.PhoneMultiFactorGenerator.getAssertion(cred);
       try {
         final cred = resolver.resolveSignIn(assertion);
         completer.complete(cred);
@@ -73,7 +73,7 @@ Future<UserCredential> startPhoneMFAVerification({
 
   SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
     provider.sendVerificationCode(
-      hint: hint as PhoneMultiFactorInfo,
+      hint: hint as fba.PhoneMultiFactorInfo,
       multiFactorSession: session,
       action: AuthAction.none,
     );

--- a/packages/firebase_ui_auth/lib/src/navigation/authentication.dart
+++ b/packages/firebase_ui_auth/lib/src/navigation/authentication.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -15,7 +15,7 @@ Future<bool> showReauthenticateDialog({
   required List<AuthProvider> providers,
 
   /// {@macro ui.auth.auth_controller.auth}
-  FirebaseAuth? auth,
+  fba.FirebaseAuth? auth,
 
   /// A callback that is being called after user has successfully signed in.
   VoidCallback? onSignedIn,
@@ -55,7 +55,7 @@ Future<void> showDifferentMethodSignInDialog({
   required List<AuthProvider> providers,
 
   /// {@macro ui.auth.auth_controller.auth}
-  FirebaseAuth? auth,
+  fba.FirebaseAuth? auth,
 
   /// A callback that is being called after user has successfully signed in.
   VoidCallback? onSignedIn,

--- a/packages/firebase_ui_auth/lib/src/navigation/forgot_password.dart
+++ b/packages/firebase_ui_auth/lib/src/navigation/forgot_password.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -13,7 +13,7 @@ Future<void> showForgotPasswordScreen({
   required BuildContext context,
 
   /// {@macro ui.auth.auth_controller.auth}
-  FirebaseAuth? auth,
+  fba.FirebaseAuth? auth,
 
   /// A email that requires password reset.
   String? email,

--- a/packages/firebase_ui_auth/lib/src/navigation/phone_verification.dart
+++ b/packages/firebase_ui_auth/lib/src/navigation/phone_verification.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart'
-    show FirebaseAuth, MultiFactorSession, PhoneMultiFactorInfo;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
 
@@ -17,13 +16,13 @@ Future<void> startPhoneVerification({
   AuthAction? action,
 
   /// {@macro ui.auth.auth_controller.auth}
-  FirebaseAuth? auth,
+  fba.FirebaseAuth? auth,
 
   /// {@macro ui.auth.providers.phone_auth_provider.mfa_session}
-  MultiFactorSession? multiFactorSession,
+  fba.MultiFactorSession? multiFactorSession,
 
   /// {@macro ui.auth.providers.phone_auth_provider.mfa_hint}
-  PhoneMultiFactorInfo? hint,
+  fba.PhoneMultiFactorInfo? hint,
 
   /// Additional actions to pass down to the [PhoneInputScreen].
   List<FirebaseUIAction> actions = const [],

--- a/packages/firebase_ui_auth/lib/src/oauth_providers.dart
+++ b/packages/firebase_ui_auth/lib/src/oauth_providers.dart
@@ -2,13 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 
 @immutable
 class ProviderKey {
-  final FirebaseAuth auth;
+  final fba.FirebaseAuth auth;
   final Type providerType;
 
   const ProviderKey(this.auth, this.providerType);
@@ -25,20 +25,20 @@ class ProviderKey {
 abstract class OAuthProviders {
   static final _providers = <ProviderKey, OAuthProvider>{};
 
-  static void register(FirebaseAuth? auth, OAuthProvider provider) {
-    final resolvedAuth = auth ?? FirebaseAuth.instance;
+  static void register(fba.FirebaseAuth? auth, OAuthProvider provider) {
+    final resolvedAuth = auth ?? fba.FirebaseAuth.instance;
     final key = ProviderKey(resolvedAuth, provider.runtimeType);
 
     _providers[key] = provider;
   }
 
-  static OAuthProvider? resolve(FirebaseAuth? auth, Type providerType) {
-    final resolvedAuth = auth ?? FirebaseAuth.instance;
+  static OAuthProvider? resolve(fba.FirebaseAuth? auth, Type providerType) {
+    final resolvedAuth = auth ?? fba.FirebaseAuth.instance;
     final key = ProviderKey(resolvedAuth, providerType);
     return _providers[key];
   }
 
-  static Iterable<OAuthProvider> providersFor(FirebaseAuth auth) sync* {
+  static Iterable<OAuthProvider> providersFor(fba.FirebaseAuth auth) sync* {
     for (final k in _providers.keys) {
       if (k.auth == auth) {
         yield _providers[k]!;
@@ -46,8 +46,8 @@ abstract class OAuthProviders {
     }
   }
 
-  static Future<void> signOut([FirebaseAuth? auth]) async {
-    final resolvedAuth = auth ?? FirebaseAuth.instance;
+  static Future<void> signOut([fba.FirebaseAuth? auth]) async {
+    final resolvedAuth = auth ?? fba.FirebaseAuth.instance;
     final providers = providersFor(resolvedAuth);
 
     for (final p in providers) {
@@ -56,7 +56,7 @@ abstract class OAuthProviders {
   }
 }
 
-extension OAuthHelpers on User {
+extension OAuthHelpers on fba.User {
   bool isProviderLinked(String providerId) {
     try {
       providerData.firstWhere((e) => e.providerId == providerId);

--- a/packages/firebase_ui_auth/lib/src/providers/auth_provider.dart
+++ b/packages/firebase_ui_auth/lib/src/providers/auth_provider.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -12,11 +12,11 @@ import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 /// After succesful execution, auth flow should have
 /// [DifferentSignInMethodsFound] state.
 void defaultOnAuthError(AuthProvider provider, Object error) {
-  if (error is! FirebaseAuthException) {
+  if (error is! fba.FirebaseAuthException) {
     throw error;
   }
 
-  if (error is FirebaseAuthMultiFactorException) {
+  if (error is fba.FirebaseAuthMultiFactorException) {
     provider.authListener.onMFARequired(error.resolver);
     return;
   }
@@ -35,7 +35,7 @@ abstract class AuthListener {
   AuthProvider get provider;
 
   /// {@macro ui.auth.auth_controller.auth}
-  FirebaseAuth get auth;
+  fba.FirebaseAuth get auth;
 
   /// Called if an error occured during the authentication process.
   void onError(Object error);
@@ -44,14 +44,14 @@ abstract class AuthListener {
   void onBeforeSignIn();
 
   /// Called if the user has successfully signed in.
-  void onSignedIn(UserCredential credential);
+  void onSignedIn(fba.UserCredential credential);
 
   /// Called before an attempt to link the credential with currently signed in
   /// user account.
-  void onCredentialReceived(AuthCredential credential);
+  void onCredentialReceived(fba.AuthCredential credential);
 
   /// Called if the credential was successfully linked with the user account.
-  void onCredentialLinked(AuthCredential credential);
+  void onCredentialLinked(fba.AuthCredential credential);
 
   /// Called before an attempt to fetch available providers for the email.
   @Deprecated(
@@ -68,23 +68,24 @@ abstract class AuthListener {
   void onDifferentProvidersFound(
     String email,
     List<String> providers,
-    AuthCredential? credential,
+    fba.AuthCredential? credential,
   );
 
   /// Called when the user cancells the sign in process.
   void onCanceled();
 
   /// Called when the user has to complete MFA.
-  void onMFARequired(MultiFactorResolver resolver);
+  void onMFARequired(fba.MultiFactorResolver resolver);
 }
 
 /// {@template ui.auth.auth_provider}
 /// An interface that all auth providers should implement.
 /// Contains shared authentication logic.
 /// {@endtemplate}
-abstract class AuthProvider<T extends AuthListener, K extends AuthCredential> {
+abstract class AuthProvider<T extends AuthListener,
+    K extends fba.AuthCredential> {
   /// {@macro ui.auth.auth_controller.auth}
-  late FirebaseAuth auth;
+  late fba.FirebaseAuth auth;
 
   /// {@template ui.auth.auth_provider.auth_listener}
   /// An instance of the [AuthListener] that is used to notify about the
@@ -143,7 +144,7 @@ abstract class AuthProvider<T extends AuthListener, K extends AuthCredential> {
   )
   void findProvidersForEmail(
     String email, [
-    AuthCredential? credential,
+    fba.AuthCredential? credential,
   ]) {
     authListener.onBeforeProvidersForEmailFetch();
 

--- a/packages/firebase_ui_auth/lib/src/providers/email_link_auth_provider.dart
+++ b/packages/firebase_ui_auth/lib/src/providers/email_link_auth_provider.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -21,9 +21,9 @@ abstract class EmailLinkAuthListener extends AuthListener {
 /// sent to the user's email.
 /// {@endtemplate}
 class EmailLinkAuthProvider
-    extends AuthProvider<EmailLinkAuthListener, AuthCredential> {
+    extends AuthProvider<EmailLinkAuthListener, fba.AuthCredential> {
   /// A configuration of the dynamic link.
-  final ActionCodeSettings actionCodeSettings;
+  final fba.ActionCodeSettings actionCodeSettings;
   final FirebaseDynamicLinks _dynamicLinks;
 
   @override
@@ -69,7 +69,7 @@ class EmailLinkAuthProvider
       _signInWithEmailLink(email, link);
     } else {
       authListener.onError(
-        FirebaseAuthException(
+        fba.FirebaseAuthException(
           code: 'invalid-email-signin-link',
           message: 'Invalid email sign in link',
         ),

--- a/packages/firebase_ui_auth/lib/src/providers/phone_auth_provider.dart
+++ b/packages/firebase_ui_auth/lib/src/providers/phone_auth_provider.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart' as fba;
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -58,12 +57,12 @@ class PhoneAuthProvider
     /// {@template ui.auth.providers.phone_auth_provider.mfa_session}
     /// Multi-factor session to use for verification
     /// {@endtemplate}
-    MultiFactorSession? multiFactorSession,
+    fba.MultiFactorSession? multiFactorSession,
 
     /// {@template ui.auth.providers.phone_auth_provider.mfa_hint}
     /// Multi-factor session info to use for verification
     /// {@endtemplate}
-    final PhoneMultiFactorInfo? hint,
+    final fba.PhoneMultiFactorInfo? hint,
   }) {
     final phone = phoneNumber ?? hint!.phoneNumber;
     authListener.onSMSCodeRequested(phone);

--- a/packages/firebase_ui_auth/lib/src/providers/universal_email_sign_in_provider.dart
+++ b/packages/firebase_ui_auth/lib/src/providers/universal_email_sign_in_provider.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/foundation.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -19,7 +19,7 @@ abstract class UniversalEmailSignInListener extends AuthListener {
   void onDifferentProvidersFound(
     String email,
     List<String> providers,
-    AuthCredential? credential,
+    fba.AuthCredential? credential,
   );
 }
 
@@ -30,7 +30,7 @@ abstract class UniversalEmailSignInListener extends AuthListener {
   'Read more here https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection',
 )
 class UniversalEmailSignInProvider
-    extends AuthProvider<UniversalEmailSignInListener, AuthCredential> {
+    extends AuthProvider<UniversalEmailSignInListener, fba.AuthCredential> {
   @override
   late UniversalEmailSignInListener authListener;
 

--- a/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:flutter/scheduler.dart';
@@ -26,7 +26,7 @@ class EmailVerifiedAction extends FirebaseUIAction {
 /// {@endtemplate}
 class EmailVerificationScreen extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.screens.responsive_page.header_builder}
   final HeaderBuilder? headerBuilder;
@@ -63,7 +63,7 @@ class EmailVerificationScreen extends StatelessWidget {
   final double breakpoint;
 
   /// A configuration object used to construct a dynamic link.
-  final ActionCodeSettings? actionCodeSettings;
+  final fba.ActionCodeSettings? actionCodeSettings;
 
   /// {@macro ui.auth.screens.email_verification_screen}
   const EmailVerificationScreen({
@@ -114,8 +114,8 @@ T? _ambiguate<T>(T? value) => value;
 
 class _EmailVerificationScreenContent extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
-  final ActionCodeSettings? actionCodeSettings;
+  final fba.FirebaseAuth? auth;
+  final fba.ActionCodeSettings? actionCodeSettings;
 
   const _EmailVerificationScreenContent({
     required this.auth,
@@ -130,8 +130,8 @@ class _EmailVerificationScreenContent extends StatefulWidget {
 class __EmailVerificationScreenContentState
     extends State<_EmailVerificationScreenContent> {
   late final controller = EmailVerificationController(auth);
-  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
-  User get user => auth.currentUser!;
+  fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
+  fba.User get user => auth.currentUser!;
   bool isLoading = false;
 
   @override

--- a/packages/firebase_ui_auth/lib/src/screens/forgot_password_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/forgot_password_screen.dart
@@ -4,7 +4,7 @@
 
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 import 'internal/responsive_page.dart';
@@ -12,7 +12,7 @@ import 'internal/responsive_page.dart';
 /// A password reset screen.
 class ForgotPasswordScreen extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A returned widget would be placed under the title of the screen.
   final WidgetBuilder? subtitleBuilder;

--- a/packages/firebase_ui_auth/lib/src/screens/internal/login_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/internal/login_screen.dart
@@ -5,13 +5,13 @@
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 
 import 'responsive_page.dart';
 
 class LoginScreen extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final AuthAction action;
   final List<AuthProvider> providers;
 

--- a/packages/firebase_ui_auth/lib/src/screens/internal/multi_provider_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/internal/multi_provider_screen.dart
@@ -2,20 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 abstract class MultiProviderScreen extends Widget {
   final List<AuthProvider>? _providers;
-  final FirebaseAuth? _auth;
-  FirebaseAuth get auth {
-    return _auth ?? FirebaseAuth.instance;
+  final fba.FirebaseAuth? _auth;
+  fba.FirebaseAuth get auth {
+    return _auth ?? fba.FirebaseAuth.instance;
   }
 
   const MultiProviderScreen({
     super.key,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     List<AuthProvider>? providers,
   })  : _auth = auth,
         _providers = providers;

--- a/packages/firebase_ui_auth/lib/src/screens/internal/provider_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/internal/provider_screen.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -10,7 +10,7 @@ abstract class ProviderScreen<T extends AuthProvider> extends StatelessWidget {
   final T? _provider;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   static final _cache = <Type, AuthProvider>{};
 
@@ -21,7 +21,7 @@ abstract class ProviderScreen<T extends AuthProvider> extends StatelessWidget {
       return _cache[T]! as T;
     }
 
-    final auth = this.auth ?? FirebaseAuth.instance;
+    final auth = this.auth ?? fba.FirebaseAuth.instance;
     final configs = FirebaseUIAuth.providersFor(auth.app);
     final config = configs.firstWhere((element) => element is T) as T;
     _cache[T] = config;

--- a/packages/firebase_ui_auth/lib/src/screens/phone_input_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/phone_input_screen.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart'
-    show FirebaseAuth, MultiFactorSession, PhoneMultiFactorInfo;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -41,7 +40,7 @@ class PhoneInputScreen extends StatelessWidget {
   final List<FirebaseUIAction>? actions;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A returned widget would be placed under the title of the screen.
   final WidgetBuilder? subtitleBuilder;
@@ -65,10 +64,10 @@ class PhoneInputScreen extends StatelessWidget {
   final double breakpoint;
 
   /// {@macro ui.auth.providers.phone_auth_provider.mfa_session}
-  final MultiFactorSession? multiFactorSession;
+  final fba.MultiFactorSession? multiFactorSession;
 
   /// {@macro ui.auth.providers.phone_auth_provider.mfa_hint}
-  final PhoneMultiFactorInfo? mfaHint;
+  final fba.PhoneMultiFactorInfo? mfaHint;
 
   const PhoneInputScreen({
     super.key,

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -2,15 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart'
-    show
-        ActionCodeSettings,
-        FirebaseAuth,
-        FirebaseAuthException,
-        MultiFactorInfo,
-        PhoneAuthCredential,
-        PhoneMultiFactorGenerator,
-        User;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart'
@@ -27,7 +19,7 @@ import 'internal/multi_provider_screen.dart';
 
 class _AvailableProvidersRow extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final List<AuthProvider> providers;
   final VoidCallback onProviderLinked;
 
@@ -75,7 +67,7 @@ class _AvailableProvidersRowState extends State<_AvailableProvidersRow> {
         );
     }
 
-    await (widget.auth ?? FirebaseAuth.instance).currentUser!.reload();
+    await (widget.auth ?? fba.FirebaseAuth.instance).currentUser!.reload();
   }
 
   @override
@@ -173,7 +165,7 @@ class _EditButton extends StatelessWidget {
 
 class _LinkedProvidersRow extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final List<AuthProvider> providers;
   final VoidCallback onProviderUnlinked;
   final bool showUnlinkConfirmationDialog;
@@ -192,7 +184,7 @@ class _LinkedProvidersRow extends StatefulWidget {
 class _LinkedProvidersRowState extends State<_LinkedProvidersRow> {
   bool isEditing = false;
   String? unlinkingProvider;
-  FirebaseAuthException? error;
+  fba.FirebaseAuthException? error;
 
   final size = 32.0;
 
@@ -246,7 +238,7 @@ class _LinkedProvidersRowState extends State<_LinkedProvidersRow> {
         widget.onProviderUnlinked();
         isEditing = false;
       });
-    } on FirebaseAuthException catch (e) {
+    } on fba.FirebaseAuthException catch (e) {
       setState(() {
         error = e;
       });
@@ -349,8 +341,8 @@ class _LinkedProvidersRowState extends State<_LinkedProvidersRow> {
 }
 
 class _EmailVerificationBadge extends StatefulWidget {
-  final FirebaseAuth auth;
-  final ActionCodeSettings? actionCodeSettings;
+  final fba.FirebaseAuth auth;
+  final fba.ActionCodeSettings? actionCodeSettings;
   const _EmailVerificationBadge({
     required this.auth,
     this.actionCodeSettings,
@@ -370,7 +362,7 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
 
   EmailVerificationState get state => service.state;
 
-  User get user {
+  fba.User get user {
     return widget.auth.currentUser!;
   }
 
@@ -473,7 +465,7 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
 
 class _MFABadge extends StatelessWidget {
   final bool enrolled;
-  final FirebaseAuth auth;
+  final fba.FirebaseAuth auth;
   final VoidCallback onToggled;
   final List<AuthProvider> providers;
 
@@ -510,7 +502,7 @@ class _MFABadge extends StatelessWidget {
 
 class _MFAToggle extends StatefulWidget {
   final bool enrolled;
-  final FirebaseAuth auth;
+  final fba.FirebaseAuth auth;
   final VoidCallback? onToggled;
   final List<AuthProvider> providers;
 
@@ -620,8 +612,8 @@ class _MFAToggleState extends State<_MFAToggle> {
       auth: widget.auth,
       actions: [
         AuthStateChangeAction<CredentialReceived>((context, state) async {
-          final cred = state.credential as PhoneAuthCredential;
-          final assertion = PhoneMultiFactorGenerator.getAssertion(cred);
+          final cred = state.credential as fba.PhoneAuthCredential;
+          final assertion = fba.PhoneMultiFactorGenerator.getAssertion(cred);
 
           try {
             await mfa.enroll(assertion);
@@ -732,7 +724,7 @@ class ProfileScreen extends MultiProviderScreen {
 
   /// A configuration object used to construct a dynamic link for email
   /// verification.
-  final ActionCodeSettings? actionCodeSettings;
+  final fba.ActionCodeSettings? actionCodeSettings;
 
   /// Indicates whether MFA tile should be shown.
   final bool showMFATile;
@@ -775,13 +767,16 @@ class ProfileScreen extends MultiProviderScreen {
     );
   }
 
-  List<AuthProvider> getLinkedProviders(User user) {
+  List<AuthProvider> getLinkedProviders(fba.User user) {
     return providers
         .where((provider) => user.isProviderLinked(provider.providerId))
         .toList();
   }
 
-  List<AuthProvider> getAvailableProviders(BuildContext context, User user) {
+  List<AuthProvider> getAvailableProviders(
+    BuildContext context,
+    fba.User user,
+  ) {
     final platform = Theme.of(context).platform;
 
     return providers
@@ -886,7 +881,7 @@ class ProfileScreen extends MultiProviderScreen {
               final user = auth.currentUser!;
               final mfa = user.multiFactor;
 
-              return FutureBuilder<List<MultiFactorInfo>>(
+              return FutureBuilder<List<fba.MultiFactorInfo>>(
                 future: mfa.getEnrolledFactors(),
                 builder: (context, snapshot) {
                   if (!snapshot.hasData) {

--- a/packages/firebase_ui_auth/lib/src/screens/sms_code_input_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/sms_code_input_screen.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -37,7 +37,7 @@ class SMSCodeInputScreen extends StatelessWidget {
   final List<FirebaseUIAction>? actions;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A unique key that could be used to obtain an instance of the
   /// [PhoneAuthController].

--- a/packages/firebase_ui_auth/lib/src/views/different_method_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/different_method_sign_in_view.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -12,7 +12,7 @@ import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 /// {@endtemplate}
 class DifferentMethodSignInView extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A list of all providers that were previously used to authenticate.
   final List<String> availableProviders;

--- a/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -15,7 +15,7 @@ import '../widgets/internal/title.dart';
 /// {@endtemplate}
 class EmailLinkSignInView extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// An instance of the [EmailLinkAuthProvider] that should be used to
   /// authenticate.

--- a/packages/firebase_ui_auth/lib/src/views/find_providers_for_email_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/find_providers_for_email_view.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -31,7 +31,7 @@ class FindProvidersForEmailView extends StatefulWidget {
   final ProvidersFoundCallback? onProvidersFound;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.views.find_providers_for_email_view}
   const FindProvidersForEmailView({

--- a/packages/firebase_ui_auth/lib/src/views/forgot_password_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/forgot_password_view.dart
@@ -5,8 +5,7 @@
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 
-import 'package:firebase_auth/firebase_auth.dart'
-    show ActionCodeSettings, FirebaseAuth, FirebaseAuthException;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import '../widgets/internal/title.dart';
@@ -16,10 +15,10 @@ import '../widgets/internal/title.dart';
 /// {@endtemplate}
 class ForgotPasswordView extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A configuration object that is used to construct a dynamic link.
-  final ActionCodeSettings? actionCodeSettings;
+  final fba.ActionCodeSettings? actionCodeSettings;
 
   /// Returned widget would be placed under the title.
   final WidgetBuilder? subtitleBuilder;
@@ -50,9 +49,9 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
   final formKey = GlobalKey<FormState>();
   bool emailSent = false;
 
-  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
+  fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
   bool isLoading = false;
-  FirebaseAuthException? exception;
+  fba.FirebaseAuthException? exception;
 
   Future<void> _submit(String email) async {
     setState(() {
@@ -67,7 +66,7 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
       );
 
       emailSent = true;
-    } on FirebaseAuthException catch (e) {
+    } on fba.FirebaseAuthException catch (e) {
       exception = e;
     } finally {
       setState(() => isLoading = false);

--- a/packages/firebase_ui_auth/lib/src/views/login_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/login_view.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart'
@@ -24,7 +24,7 @@ typedef AuthViewContentBuilder = Widget Function(
 /// {@endtemplate}
 class LoginView extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.auth_action}
   final AuthAction action;

--- a/packages/firebase_ui_auth/lib/src/views/phone_input_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/phone_input_view.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -24,7 +24,7 @@ typedef PhoneNumberSubmitCallback = void Function(String phoneNumber);
 /// {@endtemplate}
 class PhoneInputView extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.auth_action}
   final AuthAction? action;
@@ -46,10 +46,10 @@ class PhoneInputView extends StatefulWidget {
   final WidgetBuilder? footerBuilder;
 
   /// {@macro ui.auth.providers.phone_auth_provider.mfa_session}
-  final MultiFactorSession? multiFactorSession;
+  final fba.MultiFactorSession? multiFactorSession;
 
   /// {@macro ui.auth.providers.phone_auth_provider.mfa_hint}
-  final PhoneMultiFactorInfo? mfaHint;
+  final fba.PhoneMultiFactorInfo? mfaHint;
 
   /// {@macro ui.auth.views.phone_input_view}
   const PhoneInputView({

--- a/packages/firebase_ui_auth/lib/src/views/reauthenticate_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/reauthenticate_view.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -11,7 +11,7 @@ import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 /// {@endtemplate}
 class ReauthenticateView extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A list of all supported auth providers.
   final List<AuthProvider> providers;
@@ -38,7 +38,7 @@ class ReauthenticateView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final linkedProviders =
-        (auth ?? FirebaseAuth.instance).currentUser!.providerData;
+        (auth ?? fba.FirebaseAuth.instance).currentUser!.providerData;
 
     final providersMap = this.providers.fold<Map<String, AuthProvider>>(
       {},

--- a/packages/firebase_ui_auth/lib/src/views/sms_code_input_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/sms_code_input_view.dart
@@ -6,7 +6,7 @@ import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 typedef SMSCodeSubmitCallback = void Function(String smsCode);
@@ -16,7 +16,7 @@ typedef SMSCodeSubmitCallback = void Function(String smsCode);
 /// {@endtemplate}
 class SMSCodeInputView extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.auth_action}
   final AuthAction? action;

--- a/packages/firebase_ui_auth/lib/src/widgets/auth_flow_builder.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/auth_flow_builder.dart
@@ -4,8 +4,7 @@
 
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/widgets.dart';
-import 'package:firebase_auth/firebase_auth.dart'
-    show AuthCredential, FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 
 import '../auth_controller.dart';
@@ -65,7 +64,7 @@ typedef StateTransitionListener<T extends AuthController> = void Function(
 /// final passwordCtrl = TextEditingController();
 ///
 /// AuthFlowBuilder<EmailAuthController>(
-///   auth: FirebaseAuth.instance,
+///   auth: fba.FirebaseAuth.instance,
 ///   action: AuthAction.signUp,
 ///   listener: (oldState, newState, ctrl) {
 ///     if (newState is UserCreated) {
@@ -124,7 +123,7 @@ class AuthFlowBuilder<T extends AuthController> extends StatefulWidget {
   final Object? flowKey;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.auth_action}
   final AuthAction? action;
@@ -151,7 +150,7 @@ class AuthFlowBuilder<T extends AuthController> extends StatefulWidget {
   final Widget? child;
 
   /// A callback that is being called when the auth flow completes.
-  final Function(AuthCredential credential)? onComplete;
+  final Function(fba.AuthCredential credential)? onComplete;
 
   /// {@macro ui.auth.widgets.auth_flow_builder.state_transition_listener}
   final StateTransitionListener<T>? listener;
@@ -200,7 +199,7 @@ class _AuthFlowBuilderState<T extends AuthController>
   @override
   void initState() {
     super.initState();
-    provider.auth = widget.auth ?? FirebaseAuth.instance;
+    provider.auth = widget.auth ?? fba.FirebaseAuth.instance;
 
     flow = widget.flow ?? createFlow();
 

--- a/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart'
-    show FirebaseAuth, FirebaseAuthException;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
@@ -46,7 +45,7 @@ typedef SignInRequiredCallback = Future<bool> Function();
 /// {@endtemplate}
 class DeleteAccountButton extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A callback tha is called if the [FirebaseAuth] requires the user to
   /// re-authenticate and approve the account deletion. By default,
@@ -74,7 +73,7 @@ class DeleteAccountButton extends StatefulWidget {
 }
 
 class _DeleteAccountButtonState extends State<DeleteAccountButton> {
-  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
+  fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
   bool _isLoading = false;
 
   Future<void> _deleteAccount() async {
@@ -91,7 +90,7 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
         user,
       );
       await FirebaseUIAuth.signOut(context: context, auth: auth);
-    } on FirebaseAuthException catch (err) {
+    } on fba.FirebaseAuthException catch (err) {
       if (err.code == 'requires-recent-login') {
         if (widget.onSignInRequired != null) {
           final signedIn = await widget.onSignInRequired!();

--- a/packages/firebase_ui_auth/lib/src/widgets/different_method_sign_in_dialog.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/different_method_sign_in_dialog.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -16,7 +16,7 @@ import '../widgets/internal/title.dart';
 /// {@endtemplate}
 class DifferentMethodSignInDialog extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A list of all providers that were previously used to authenticate.
   final List<String> availableProviders;

--- a/packages/firebase_ui_auth/lib/src/widgets/editable_user_display_name.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/editable_user_display_name.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
@@ -33,7 +33,7 @@ import 'internal/subtitle.dart';
 /// {@endtemplate}
 class EditableUserDisplayName extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.widgets.editable_user_display_name}
   const EditableUserDisplayName({
@@ -48,7 +48,7 @@ class EditableUserDisplayName extends StatefulWidget {
 }
 
 class _EditableUserDisplayNameState extends State<EditableUserDisplayName> {
-  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
+  fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
   String? get displayName => auth.currentUser?.displayName;
 
   late final ctrl = TextEditingController(text: displayName ?? '');

--- a/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
@@ -83,7 +83,7 @@ class EmailFormStyle extends FirebaseUIStyle {
 /// {@endtemplate}
 class EmailForm extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.auth_action}
   final AuthAction? action;
@@ -173,7 +173,7 @@ class EmailForm extends StatelessWidget {
 
 class _SignInFormContent extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final EmailFormSubmitCallback? onSubmit;
 
   /// {@macro ui.auth.auth_action}

--- a/packages/firebase_ui_auth/lib/src/widgets/email_link_sign_in_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_link_sign_in_button.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -20,7 +20,7 @@ import 'internal/universal_page_route.dart';
 /// {@endtemplate}
 class EmailLinkSignInButton extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// An instance of [EmailLinkAuthProvider] that should be used to
   /// authenticate.

--- a/packages/firebase_ui_auth/lib/src/widgets/email_sign_up_dialog.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_sign_up_dialog.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide EmailAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
@@ -15,7 +15,7 @@ import 'internal/title.dart';
 /// {@endtemplate}
 class EmailSignUpDialog extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.auth_action}
   final AuthAction? action;

--- a/packages/firebase_ui_auth/lib/src/widgets/error_text.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/error_text.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuthException;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -43,7 +43,7 @@ class ErrorText extends StatelessWidget {
   ///
   /// Example usage:
   /// ```dart
-  /// ErrorText.localizeError = (BuildContext context, FirebaseAuthException e) {
+  /// ErrorText.localizeError = (BuildContext context, fba.FirebaseAuthException e) {
   ///   return switch (e.code) {
   ///     'user-not-found' => 'Please create an account first.',
   ///     'credential-already-in-use' => 'This email is already in use.',
@@ -52,7 +52,7 @@ class ErrorText extends StatelessWidget {
   /// }
   static String Function(
     BuildContext context,
-    FirebaseAuthException exception,
+    fba.FirebaseAuthException exception,
   )? localizeError;
 
   /// A way to customize error message for [PlatformException]
@@ -106,11 +106,11 @@ class ErrorText extends StatelessWidget {
       text = l.smsAutoresolutionFailedError;
     }
 
-    if (exception is FirebaseAuthException) {
+    if (exception is fba.FirebaseAuthException) {
       if (localizeError != null) {
-        text = localizeError!(context, exception as FirebaseAuthException);
+        text = localizeError!(context, exception as fba.FirebaseAuthException);
       } else {
-        final e = exception as FirebaseAuthException;
+        final e = exception as fba.FirebaseAuthException;
         final code = e.code;
         final newText = localizedErrorText(code, l) ?? e.message;
 

--- a/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -51,7 +51,7 @@ class OAuthProviderButton extends StatelessWidget {
   final AuthAction? action;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.widgets.oauth_provider_button.oauth_button_variant}
   final OAuthButtonVariant? variant;

--- a/packages/firebase_ui_auth/lib/src/widgets/phone_verification_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/phone_verification_button.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -16,7 +16,7 @@ import 'package:flutter/material.dart';
 /// {@endtemplate}
 class PhoneVerificationButton extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.auth.auth_action}
   final AuthAction? action;

--- a/packages/firebase_ui_auth/lib/src/widgets/reauthenticate_dialog.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/reauthenticate_dialog.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -16,7 +16,7 @@ import 'internal/title.dart';
 /// {@endtemplate}
 class ReauthenticateDialog extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// A list of all supported auth providers.
   final List<AuthProvider> providers;

--- a/packages/firebase_ui_auth/lib/src/widgets/sign_out_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/sign_out_button.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -14,7 +14,7 @@ import 'package:flutter/material.dart';
 /// {@endtemplate}
 class SignOutButton extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@macro ui.shared.widgets.button_variant}
   final ButtonVariant variant;

--- a/packages/firebase_ui_auth/lib/src/widgets/user_avatar.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/user_avatar.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 
 /// {@template ui.auth.widgets.user_avatar}
@@ -13,7 +13,7 @@ import 'package:flutter/material.dart';
 /// {@endtemplate}
 class UserAvatar extends StatefulWidget {
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@template ui.auth.widgets.user_avatar.size}
   /// A size of the avatar.
@@ -45,7 +45,7 @@ class UserAvatar extends StatefulWidget {
 }
 
 class _UserAvatarState extends State<UserAvatar> {
-  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
+  fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
   ShapeBorder get shape => widget.shape ?? const CircleBorder();
   Color get placeholderColor => widget.placeholderColor ?? Colors.grey;
   double get size => widget.size ?? 120;

--- a/packages/firebase_ui_auth/test/flows/email_link_flow_test.dart
+++ b/packages/firebase_ui_auth/test/flows/email_link_flow_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -18,7 +18,7 @@ void main() {
   late EmailLinkFlow flow;
   late EmailLinkAuthController ctrl;
 
-  final actionCodeSettings = ActionCodeSettings(
+  final actionCodeSettings = fba.ActionCodeSettings(
     url: 'https://example.com',
     handleCodeInApp: true,
     androidPackageName: 'com.test.app',
@@ -58,7 +58,7 @@ void main() {
         expect(result.captured, ['test@test.com']);
       });
 
-      test('calls FirebaseAuth#sendSignInLinkToEmail', () {
+      test('calls fba.FirebaseAuth#sendSignInLinkToEmail', () {
         provider.authListener = listener;
         provider.sendLink('test@test.com');
 
@@ -135,12 +135,12 @@ void main() {
 
         final result = verify(listener.onError(captureAny));
         result.called(1);
-        expect(result.captured[0], isA<FirebaseAuthException>());
+        expect(result.captured[0], isA<fba.FirebaseAuthException>());
         expect(result.captured[0].code, 'invalid-email-signin-link');
       });
 
       test(
-        'calls FirebaseAuth#signInWithEmailLink when got a valid sign in link',
+        'calls fba.FirebaseAuth#signInWithEmailLink when got a valid sign in link',
         () async {
           provider.authListener = listener;
           provider.awaitLink('test@test.com');
@@ -329,7 +329,7 @@ class MockProvider extends Mock implements EmailLinkAuthProvider {
 
 class MockListener extends Mock implements EmailLinkAuthListener {
   @override
-  void onSignedIn(UserCredential? credential) {
+  void onSignedIn(fba.UserCredential? credential) {
     super.noSuchMethod(Invocation.method(#onSignedIn, [credential]));
   }
 

--- a/packages/firebase_ui_auth/test/flows/phone_auth_flow_test.dart
+++ b/packages/firebase_ui_auth/test/flows/phone_auth_flow_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide PhoneAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -40,7 +40,7 @@ void main() {
         expect(invocation.callCount, 1);
       });
 
-      test('calls FirebaseAuth#verifyPhoneNumber', () async {
+      test('calls fba.FirebaseAuth#verifyPhoneNumber', () async {
         provider.sendVerificationCode(
           phoneNumber: '+123456789',
           action: AuthAction.signIn,
@@ -187,7 +187,7 @@ void main() {
 
     group('#verifySMSCode', () {
       test(
-        'calls FirebaseAuth#signInWithCredential if action is sign in',
+        'calls fba.FirebaseAuth#signInWithCredential if action is sign in',
         () {
           provider.verifySMSCode(
             action: AuthAction.signIn,
@@ -198,9 +198,9 @@ void main() {
           final invocation = verify(auth.signInWithCredential(captureAny));
 
           expect(invocation.callCount, 1);
-          expect(invocation.captured.first, isA<PhoneAuthCredential>());
+          expect(invocation.captured.first, isA<fba.PhoneAuthCredential>());
 
-          final cred = invocation.captured.first as PhoneAuthCredential;
+          final cred = invocation.captured.first as fba.PhoneAuthCredential;
 
           expect(cred.smsCode, '123456');
           expect(cred.verificationId, 'verificationId');
@@ -280,9 +280,9 @@ void main() {
         );
 
         expect(invocation.callCount, 1);
-        expect(invocation.captured.first, isA<PhoneAuthCredential>());
+        expect(invocation.captured.first, isA<fba.PhoneAuthCredential>());
 
-        final cred = invocation.captured.first as PhoneAuthCredential;
+        final cred = invocation.captured.first as fba.PhoneAuthCredential;
 
         expect(cred.smsCode, '123456');
         expect(cred.verificationId, 'verificationId');
@@ -305,9 +305,9 @@ void main() {
           final invocation = verify(listener.onCredentialLinked(captureAny));
 
           expect(invocation.callCount, 1);
-          expect(invocation.captured.first, isA<PhoneAuthCredential>());
+          expect(invocation.captured.first, isA<fba.PhoneAuthCredential>());
 
-          final cred = invocation.captured.first as PhoneAuthCredential;
+          final cred = invocation.captured.first as fba.PhoneAuthCredential;
 
           expect(cred.smsCode, '123456');
           expect(cred.verificationId, 'verificationId');
@@ -367,8 +367,8 @@ class MockProvider extends Mock implements PhoneAuthProvider {
     String? phoneNumber,
     AuthAction? action,
     int? forceResendingToken,
-    MultiFactorSession? multiFactorSession,
-    PhoneMultiFactorInfo? hint,
+    fba.MultiFactorSession? multiFactorSession,
+    fba.PhoneMultiFactorInfo? hint,
   }) {
     super.noSuchMethod(
       Invocation.method(
@@ -390,7 +390,7 @@ class MockProvider extends Mock implements PhoneAuthProvider {
     AuthAction? action,
     String? code,
     String? verificationId,
-    ConfirmationResult? confirmationResult,
+    fba.ConfirmationResult? confirmationResult,
   }) {
     super.noSuchMethod(
       Invocation.method(
@@ -407,9 +407,9 @@ class MockProvider extends Mock implements PhoneAuthProvider {
   }
 }
 
-class MockUserCredential extends Mock implements UserCredential {}
+class MockUserCredential extends Mock implements fba.UserCredential {}
 
-class MockPhoneCredential extends Mock implements PhoneAuthCredential {}
+class MockPhoneCredential extends Mock implements fba.PhoneAuthCredential {}
 
 class MockListener extends Mock implements PhoneAuthListener {
   @override
@@ -436,7 +436,7 @@ class MockListener extends Mock implements PhoneAuthListener {
   }
 
   @override
-  void onCredentialLinked(AuthCredential? credential) {
+  void onCredentialLinked(fba.AuthCredential? credential) {
     super.noSuchMethod(
       Invocation.method(
         #onCredentialLinked,
@@ -446,7 +446,7 @@ class MockListener extends Mock implements PhoneAuthListener {
   }
 
   @override
-  void onVerificationCompleted(PhoneAuthCredential? credential) {
+  void onVerificationCompleted(fba.PhoneAuthCredential? credential) {
     super.noSuchMethod(
       Invocation.method(
         #onVerificationCompleted,
@@ -466,7 +466,7 @@ class MockListener extends Mock implements PhoneAuthListener {
   }
 
   @override
-  void onCredentialReceived(AuthCredential? credential) {
+  void onCredentialReceived(fba.AuthCredential? credential) {
     super.noSuchMethod(
       Invocation.method(
         #onBeforeCredentialLinked,
@@ -476,7 +476,7 @@ class MockListener extends Mock implements PhoneAuthListener {
   }
 
   @override
-  void onSignedIn(UserCredential? credential) {
+  void onSignedIn(fba.UserCredential? credential) {
     super.noSuchMethod(
       Invocation.method(
         #onSignedIn,

--- a/packages/firebase_ui_auth/test/flows/universal_email_sign_in_flow_test.dart
+++ b/packages/firebase_ui_auth/test/flows/universal_email_sign_in_flow_test.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: deprecated_member_use_from_same_package
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:mockito/mockito.dart';
@@ -31,7 +31,7 @@ void main() {
     });
 
     group('#findProvidersForEmail', () {
-      test('calls FirebaseAuth#fetchSignInMethodsForEmail', () {
+      test('calls fba.FirebaseAuth#fetchSignInMethodsForEmail', () {
         provider.findProvidersForEmail('test@test.com');
         final invocation = verify(auth.fetchSignInMethodsForEmail(captureAny));
 
@@ -120,7 +120,7 @@ class MockListener extends Mock implements UniversalEmailSignInListener {
   void onDifferentProvidersFound(
     String? email,
     List<String>? providers,
-    AuthCredential? credential,
+    fba.AuthCredential? credential,
   ) {
     super.noSuchMethod(
       Invocation.method(
@@ -142,7 +142,7 @@ class MockProvider extends Mock implements UniversalEmailSignInProvider {
   @override
   void findProvidersForEmail(
     String? email, [
-    AuthCredential? credential,
+    fba.AuthCredential? credential,
   ]) {
     super.noSuchMethod(
       Invocation.method(

--- a/packages/firebase_ui_auth/test/test_utils.dart
+++ b/packages/firebase_ui_auth/test/test_utils.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:flutter/material.dart';
@@ -23,23 +23,25 @@ class TestMaterialApp extends StatelessWidget {
   }
 }
 
-class MockCredential extends Mock implements UserCredential {}
+class MockCredential extends Mock implements fba.UserCredential {}
 
-class MockUserInfo extends Mock implements UserInfo {
+class MockUserInfo extends Mock implements fba.UserInfo {
   @override
   final String providerId;
 
   MockUserInfo({required this.providerId});
 }
 
-class MockUser extends Mock implements User {
+class MockUser extends Mock implements fba.User {
   @override
-  final List<UserInfo> providerData;
+  final List<fba.UserInfo> providerData;
 
   MockUser({this.providerData = const []});
 
   @override
-  Future<UserCredential> linkWithCredential(AuthCredential? credential) async {
+  Future<fba.UserCredential> linkWithCredential(
+    fba.AuthCredential? credential,
+  ) async {
     return super.noSuchMethod(
       Invocation.method(
         #linkWithCredential,
@@ -75,11 +77,11 @@ class MockDynamicLinks extends Mock implements FirebaseDynamicLinks {
 
 class MockApp extends Mock implements FirebaseApp {}
 
-class MockAuth extends Mock implements FirebaseAuth {
+class MockAuth extends Mock implements fba.FirebaseAuth {
   MockUser? user;
 
   @override
-  User? get currentUser => user;
+  fba.User? get currentUser => user;
 
   @override
   FirebaseApp get app => MockApp();
@@ -87,8 +89,8 @@ class MockAuth extends Mock implements FirebaseAuth {
   List<FirebaseApp> get apps => [app];
 
   @override
-  Future<UserCredential> signInWithCredential(
-    AuthCredential? credential,
+  Future<fba.UserCredential> signInWithCredential(
+    fba.AuthCredential? credential,
   ) async {
     return super.noSuchMethod(
       Invocation.method(
@@ -101,7 +103,7 @@ class MockAuth extends Mock implements FirebaseAuth {
   }
 
   @override
-  Future<UserCredential> createUserWithEmailAndPassword({
+  Future<fba.UserCredential> createUserWithEmailAndPassword({
     String? email,
     String? password,
   }) async {
@@ -118,7 +120,7 @@ class MockAuth extends Mock implements FirebaseAuth {
   @override
   Future<void> sendSignInLinkToEmail({
     required String? email,
-    required ActionCodeSettings? actionCodeSettings,
+    required fba.ActionCodeSettings? actionCodeSettings,
   }) async {
     return super.noSuchMethod(
       Invocation.method(
@@ -146,7 +148,7 @@ class MockAuth extends Mock implements FirebaseAuth {
   }
 
   @override
-  Future<UserCredential> signInWithEmailLink({
+  Future<fba.UserCredential> signInWithEmailLink({
     required String? email,
     required String? emailLink,
   }) async {
@@ -179,15 +181,15 @@ class MockAuth extends Mock implements FirebaseAuth {
   @override
   Future<void> verifyPhoneNumber({
     String? phoneNumber,
-    PhoneMultiFactorInfo? multiFactorInfo,
-    PhoneVerificationCompleted? verificationCompleted,
-    PhoneVerificationFailed? verificationFailed,
-    PhoneCodeSent? codeSent,
-    PhoneCodeAutoRetrievalTimeout? codeAutoRetrievalTimeout,
+    fba.PhoneMultiFactorInfo? multiFactorInfo,
+    fba.PhoneVerificationCompleted? verificationCompleted,
+    fba.PhoneVerificationFailed? verificationFailed,
+    fba.PhoneCodeSent? codeSent,
+    fba.PhoneCodeAutoRetrievalTimeout? codeAutoRetrievalTimeout,
     String? autoRetrievedSmsCodeForTesting,
     Duration timeout = const Duration(seconds: 30),
     int? forceResendingToken,
-    MultiFactorSession? multiFactorSession,
+    fba.MultiFactorSession? multiFactorSession,
   }) async {
     super.noSuchMethod(
       Invocation.method(

--- a/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/email_link_sign_in_view_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart';
@@ -19,7 +19,7 @@ void main() {
   setUp(() {
     auth = MockAuth();
     dynamicLinks = MockDynamicLinks();
-    final actionCodeSettings = ActionCodeSettings(
+    final actionCodeSettings = fba.ActionCodeSettings(
       url: 'https://example.com',
     );
     emailLinkProvider = EmailLinkAuthProvider(

--- a/packages/firebase_ui_auth/test/views/forgot_password_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/forgot_password_view_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,11 +10,11 @@ import 'package:mockito/mockito.dart';
 
 import '../test_utils.dart';
 
-class MockFirebaseAuth extends Mock implements FirebaseAuth {
+class MockFirebaseAuth extends Mock implements fba.FirebaseAuth {
   @override
   Future<void> sendPasswordResetEmail({
     String? email,
-    ActionCodeSettings? actionCodeSettings,
+    fba.ActionCodeSettings? actionCodeSettings,
   }) {
     return super.noSuchMethod(
       Invocation.method(
@@ -44,7 +44,7 @@ void main() {
       );
 
       when(auth.sendPasswordResetEmail(email: 'invalid@email')).thenThrow(
-        FirebaseAuthException(
+        fba.FirebaseAuthException(
           message: 'invalid-email',
           code: 'invalid-email',
         ),

--- a/packages/firebase_ui_auth/test/widgets/email_form_test.dart
+++ b/packages/firebase_ui_auth/test/widgets/email_form_test.dart
@@ -5,14 +5,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:mockito/mockito.dart';
 
 import 'package:firebase_ui_auth/src/widgets/internal/universal_text_form_field.dart';
 
 import '../test_utils.dart';
 
-class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockFirebaseAuth extends Mock implements fba.FirebaseAuth {}
 
 void main() {
   group('EmailForm', () {

--- a/packages/firebase_ui_auth/test/widgets/error_text_test.dart
+++ b/packages/firebase_ui_auth/test/widgets/error_text_test.dart
@@ -2,14 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  final exception = FirebaseAuthException(
+  final exception = fba.FirebaseAuthException(
     code: 'invalid-email',
     message: 'The email address is badly formatted.',
   );
@@ -37,7 +37,7 @@ void main() {
     testWidgets('allows to override error text', (tester) async {
       String localizeError(
         BuildContext context,
-        FirebaseAuthException exception,
+        fba.FirebaseAuthException exception,
       ) {
         expect(exception.code, 'invalid-email');
         return 'Custom error text';

--- a/packages/firebase_ui_localizations/lib/src/default_localizations.dart
+++ b/packages/firebase_ui_localizations/lib/src/default_localizations.dart
@@ -287,7 +287,7 @@ abstract class FirebaseUILocalizationLabels {
   String get ulinkProviderAlertTitle;
 
   /// Used as a generic error message when unable to resolve error details from
-  /// Exception or FirebaseAuthException.
+  /// Exception or fba.FirebaseAuthException.
   String get unknownError;
 
   /// Text that is shown as a message of the AlertDialog confirming provider

--- a/packages/firebase_ui_oauth/lib/src/oauth_provider_button_base.dart
+++ b/packages/firebase_ui_oauth/lib/src/oauth_provider_button_base.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -20,13 +20,13 @@ typedef ErrorBuilder = Widget Function(Exception e);
 /// {@endtemplate}
 typedef DifferentProvidersFoundCallback = void Function(
   List<String> providers,
-  AuthCredential? credential,
+  fba.AuthCredential? credential,
 );
 
 /// {@template ui.oauth.oauth_provider_button_base.signed_in_callback}
 /// A callback that is being called when the user signs in.
 /// {@endtemplate}
-typedef SignedInCallback = void Function(UserCredential credential);
+typedef SignedInCallback = void Function(fba.UserCredential credential);
 
 /// {@template ui.oauth.oauth_provider_button_base}
 /// A base widget that allows authentication using OAuth providers.
@@ -53,7 +53,7 @@ class OAuthProviderButtonBase extends StatefulWidget {
   final AuthAction? action;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
 
   /// {@template ui.oauth.oauth_provider_button.on_tap}
   /// A callback that is being called when the button is tapped.
@@ -152,7 +152,7 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
   void initState() {
     super.initState();
 
-    provider.auth = widget.auth ?? FirebaseAuth.instance;
+    provider.auth = widget.auth ?? fba.FirebaseAuth.instance;
     provider.authListener = this;
   }
 
@@ -284,7 +284,7 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
   }
 
   @override
-  FirebaseAuth get auth => widget.auth ?? FirebaseAuth.instance;
+  fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
 
   void safeSetState(void Function() update) {
     if (mounted) {
@@ -293,14 +293,14 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
   }
 
   @override
-  void onCredentialReceived(AuthCredential credential) {
+  void onCredentialReceived(fba.AuthCredential credential) {
     safeSetState(() {
       isLoading = true;
     });
   }
 
   @override
-  void onMFARequired(MultiFactorResolver resolver) {
+  void onMFARequired(fba.MultiFactorResolver resolver) {
     startMFAVerification(context: context, resolver: resolver);
   }
 
@@ -319,7 +319,7 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
   }
 
   @override
-  void onCredentialLinked(AuthCredential credential) {
+  void onCredentialLinked(fba.AuthCredential credential) {
     safeSetState(() {
       isLoading = false;
     });
@@ -329,13 +329,13 @@ class _OAuthProviderButtonBaseState extends State<OAuthProviderButtonBase>
   void onDifferentProvidersFound(
     String email,
     List<String> providers,
-    AuthCredential? credential,
+    fba.AuthCredential? credential,
   ) {
     widget.onDifferentProvidersFound?.call(providers, credential);
   }
 
   @override
-  void onSignedIn(UserCredential credential) {
+  void onSignedIn(fba.UserCredential credential) {
     safeSetState(() {
       isLoading = false;
     });

--- a/packages/firebase_ui_oauth/lib/src/platform_oauth_sign_in.dart
+++ b/packages/firebase_ui_oauth/lib/src/platform_oauth_sign_in.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:desktop_webview_auth/desktop_webview_auth.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -18,10 +18,10 @@ mixin PlatformSignInMixin {
   dynamic get firebaseAuthProvider;
 
   /// Creates [OAuthCredential] based on [AuthResult].
-  OAuthCredential fromDesktopAuthResult(AuthResult result);
+  fba.OAuthCredential fromDesktopAuthResult(AuthResult result);
 
   /// {@macro ui.auth.auth_provider.on_credential_received}
-  void onCredentialReceived(OAuthCredential credential, AuthAction action);
+  void onCredentialReceived(fba.OAuthCredential credential, AuthAction action);
 
   /// {@template ui.oauth.platform_sign_in_mixin.platform_sign_in}
   /// Redirects the flow to the [mobileSignIn] or [desktopSignIn] based

--- a/packages/firebase_ui_oauth/lib/src/platform_oauth_sign_in_web.dart
+++ b/packages/firebase_ui_oauth/lib/src/platform_oauth_sign_in_web.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
@@ -10,11 +10,11 @@ import 'oauth_provider.dart';
 
 /// {@macro ui.oauth.platform_sign_in_mixin}
 mixin PlatformSignInMixin {
-  FirebaseAuth get auth;
+  fba.FirebaseAuth get auth;
   OAuthListener get authListener;
   dynamic get firebaseAuthProvider;
 
-  void _webOnLinked(UserCredential userCredential) {
+  void _webOnLinked(fba.UserCredential userCredential) {
     return authListener.onCredentialLinked(userCredential.credential!);
   }
 

--- a/packages/firebase_ui_oauth/test/flutterfire_ui_oauth_test.dart
+++ b/packages/firebase_ui_oauth/test/flutterfire_ui_oauth_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 import 'package:flutter/material.dart';
@@ -99,7 +99,7 @@ class FakeOAuthProvider extends OAuthProvider {
   }
 }
 
-class FakeAuth extends Fake implements FirebaseAuth {}
+class FakeAuth extends Fake implements fba.FirebaseAuth {}
 
 void main() {
   final provider = FakeOAuthProvider();

--- a/packages/firebase_ui_oauth_apple/lib/firebase_ui_oauth_apple.dart
+++ b/packages/firebase_ui_oauth_apple/lib/firebase_ui_oauth_apple.dart
@@ -5,7 +5,7 @@
 export 'src/provider.dart' show AppleProvider;
 export 'src/theme.dart' show AppleProviderButtonStyle;
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 
@@ -16,7 +16,7 @@ class AppleSignInButton extends _AppleSignInButton {
     Key? key,
     required Widget loadingIndicator,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     String? label,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
@@ -48,7 +48,7 @@ class AppleSignInIconButton extends _AppleSignInButton {
     Key? key,
     required Widget loadingIndicator,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
     SignedInCallback? onSignedIn,
@@ -92,7 +92,7 @@ class _AppleSignInButton extends StatelessWidget {
   final AuthAction? action;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final DifferentProvidersFoundCallback? onDifferentProvidersFound;
   final SignedInCallback? onSignedIn;
   final double size;
@@ -134,7 +134,7 @@ class _AppleSignInButton extends StatelessWidget {
       loadingIndicator: loadingIndicator,
       isLoading: isLoading,
       action: action,
-      auth: auth ?? FirebaseAuth.instance,
+      auth: auth ?? fba.FirebaseAuth.instance,
       onDifferentProvidersFound: onDifferentProvidersFound,
       onSignedIn: onSignedIn,
       overrideDefaultTapAction: overrideDefaultTapAction,

--- a/packages/firebase_ui_oauth_facebook/lib/firebase_ui_oauth_facebook.dart
+++ b/packages/firebase_ui_oauth_facebook/lib/firebase_ui_oauth_facebook.dart
@@ -5,7 +5,7 @@
 export 'src/provider.dart' show FacebookProvider;
 export 'src/theme.dart' show FacebookProviderButtonStyle;
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
@@ -19,7 +19,7 @@ class FacebookSignInButton extends _FacebookSignInButton {
     required String clientId,
     String? redirectUri,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     String? label,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
@@ -54,7 +54,7 @@ class FacebookSignInIconButton extends _FacebookSignInButton {
     required String clientId,
     required Widget loadingIndicator,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
     SignedInCallback? onSignedIn,
@@ -101,7 +101,7 @@ class _FacebookSignInButton extends StatelessWidget {
   final AuthAction? action;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final DifferentProvidersFoundCallback? onDifferentProvidersFound;
   final SignedInCallback? onSignedIn;
   final double size;
@@ -148,7 +148,7 @@ class _FacebookSignInButton extends StatelessWidget {
       loadingIndicator: loadingIndicator,
       isLoading: isLoading,
       action: action,
-      auth: auth ?? FirebaseAuth.instance,
+      auth: auth ?? fba.FirebaseAuth.instance,
       onDifferentProvidersFound: onDifferentProvidersFound,
       onSignedIn: onSignedIn,
       overrideDefaultTapAction: overrideDefaultTapAction,

--- a/packages/firebase_ui_oauth_facebook/lib/src/provider.dart
+++ b/packages/firebase_ui_oauth_facebook/lib/src/provider.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/foundation.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
@@ -34,7 +34,7 @@ class FacebookProvider extends OAuthProvider {
     switch (result.status) {
       case LoginStatus.success:
         final token = result.accessToken!.token;
-        final credential = FacebookAuthProvider.credential(token);
+        final credential = fba.FacebookAuthProvider.credential(token);
 
         onCredentialReceived(credential, action);
         break;
@@ -53,11 +53,12 @@ class FacebookProvider extends OAuthProvider {
 
   @override
   OAuthCredential fromDesktopAuthResult(AuthResult result) {
-    return FacebookAuthProvider.credential(result.accessToken!);
+    return fba.FacebookAuthProvider.credential(result.accessToken!);
   }
 
   @override
-  FacebookAuthProvider get firebaseAuthProvider => FacebookAuthProvider();
+  fba.FacebookAuthProvider get firebaseAuthProvider =>
+      fba.FacebookAuthProvider();
 
   @override
   Future<void> logOutProvider() async {

--- a/packages/firebase_ui_oauth_google/lib/firebase_ui_oauth_google.dart
+++ b/packages/firebase_ui_oauth_google/lib/firebase_ui_oauth_google.dart
@@ -5,7 +5,7 @@
 export 'src/provider.dart' show GoogleProvider;
 export 'src/theme.dart' show GoogleProviderButtonStyle;
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 
@@ -19,7 +19,7 @@ class GoogleSignInButton extends _GoogleSignInButton {
     String? redirectUri,
     List<String>? scopes,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     String? label,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
@@ -56,7 +56,7 @@ class GoogleSignInIconButton extends _GoogleSignInButton {
     required Widget loadingIndicator,
     List<String>? scopes,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
     SignedInCallback? onSignedIn,
@@ -104,7 +104,7 @@ class _GoogleSignInButton extends StatelessWidget {
   final AuthAction? action;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final DifferentProvidersFoundCallback? onDifferentProvidersFound;
   final SignedInCallback? onSignedIn;
   final double size;
@@ -154,7 +154,7 @@ class _GoogleSignInButton extends StatelessWidget {
       loadingIndicator: loadingIndicator,
       isLoading: isLoading,
       action: action,
-      auth: auth ?? FirebaseAuth.instance,
+      auth: auth ?? fba.FirebaseAuth.instance,
       onDifferentProvidersFound: onDifferentProvidersFound,
       onSignedIn: onSignedIn,
       overrideDefaultTapAction: overrideDefaultTapAction,

--- a/packages/firebase_ui_oauth_google/lib/src/provider.dart
+++ b/packages/firebase_ui_oauth_google/lib/src/provider.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/foundation.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 import 'package:firebase_ui_oauth_google/firebase_ui_oauth_google.dart';
@@ -31,7 +31,7 @@ class GoogleProvider extends OAuthProvider {
   late GoogleSignIn provider;
 
   @override
-  final GoogleAuthProvider firebaseAuthProvider = GoogleAuthProvider();
+  final fba.GoogleAuthProvider firebaseAuthProvider = fba.GoogleAuthProvider();
 
   @override
   late final desktopSignInArgs = GoogleSignInArgs(
@@ -77,7 +77,7 @@ class GoogleProvider extends OAuthProvider {
       if (user == null) throw AuthCancelledException();
       return user.authentication;
     }).then((auth) {
-      final credential = GoogleAuthProvider.credential(
+      final credential = fba.GoogleAuthProvider.credential(
         accessToken: auth.accessToken,
         idToken: auth.idToken,
       );
@@ -90,7 +90,7 @@ class GoogleProvider extends OAuthProvider {
 
   @override
   OAuthCredential fromDesktopAuthResult(AuthResult result) {
-    return GoogleAuthProvider.credential(
+    return fba.GoogleAuthProvider.credential(
       idToken: result.idToken,
       accessToken: result.accessToken,
     );

--- a/packages/firebase_ui_oauth_twitter/lib/firebase_ui_oauth_twitter.dart
+++ b/packages/firebase_ui_oauth_twitter/lib/firebase_ui_oauth_twitter.dart
@@ -5,7 +5,7 @@
 export 'src/provider.dart' show TwitterProvider;
 export 'src/theme.dart' show TwitterProviderButtonStyle;
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 
@@ -19,7 +19,7 @@ class TwitterSignInButton extends _TwitterSignInButton {
     required String apiSecretKey,
     String? redirectUri,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     String? label,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
@@ -56,7 +56,7 @@ class TwitterSignInIconButton extends _TwitterSignInButton {
     required String apiSecretKey,
     required Widget loadingIndicator,
     AuthAction? action,
-    FirebaseAuth? auth,
+    fba.FirebaseAuth? auth,
     bool? isLoading,
     DifferentProvidersFoundCallback? onDifferentProvidersFound,
     SignedInCallback? onSignedIn,
@@ -104,7 +104,7 @@ class _TwitterSignInButton extends StatelessWidget {
   final AuthAction? action;
 
   /// {@macro ui.auth.auth_controller.auth}
-  final FirebaseAuth? auth;
+  final fba.FirebaseAuth? auth;
   final DifferentProvidersFoundCallback? onDifferentProvidersFound;
   final SignedInCallback? onSignedIn;
   final double size;
@@ -154,7 +154,7 @@ class _TwitterSignInButton extends StatelessWidget {
       loadingIndicator: loadingIndicator,
       isLoading: isLoading,
       action: action,
-      auth: auth ?? FirebaseAuth.instance,
+      auth: auth ?? fba.FirebaseAuth.instance,
       onDifferentProvidersFound: onDifferentProvidersFound,
       onSignedIn: onSignedIn,
       overrideDefaultTapAction: overrideDefaultTapAction,

--- a/tests/integration_test/firebase_ui_auth/email_form_test.dart
+++ b/tests/integration_test/firebase_ui_auth/email_form_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -197,13 +197,13 @@ void main() {
               AuthStateChangeAction<CredentialLinked>((context, state) {
                 expect(state, isA<CredentialLinked>());
                 expect(state.credential, isNotNull);
-                expect(state.credential, isA<EmailAuthCredential>());
+                expect(state.credential, isA<fba.EmailAuthCredential>());
                 expect(
-                  (state.credential as EmailAuthCredential).email,
+                  (state.credential as fba.EmailAuthCredential).email,
                   equals('test@test.com'),
                 );
                 expect(
-                  (state.credential as EmailAuthCredential).password,
+                  (state.credential as fba.EmailAuthCredential).password,
                   equals('password'),
                 );
 

--- a/tests/integration_test/firebase_ui_auth/email_link_sign_in_view_test.dart
+++ b/tests/integration_test/firebase_ui_auth/email_link_sign_in_view_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -10,7 +10,7 @@ import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
 import '../utils.dart';
 
-final actionCodeSettings = ActionCodeSettings(
+final actionCodeSettings = fba.ActionCodeSettings(
   url: 'http://$testEmulatorHost:9099',
   handleCodeInApp: true,
   androidMinimumVersion: '1',

--- a/tests/integration_test/firebase_ui_auth/layout_test.dart
+++ b/tests/integration_test/firebase_ui_auth/layout_test.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart'
-    hide EmailAuthProvider, PhoneAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_oauth_apple/firebase_ui_oauth_apple.dart';
 import 'package:firebase_ui_oauth_google/firebase_ui_oauth_google.dart';
@@ -55,19 +54,19 @@ const _user = {
   'isEmailVerified': false,
 };
 
-class MockUser extends Mock implements User {
+class MockUser extends Mock implements fba.User {
   @override
-  List<UserInfo> get providerData {
+  List<fba.UserInfo> get providerData {
     return [
-      UserInfo.fromJson({..._user, 'providerId': 'password'}),
-      UserInfo.fromJson({..._user, 'providerId': 'google.com'}),
-      UserInfo.fromJson({..._user, 'providerId': 'apple.com'}),
-      UserInfo.fromJson({..._user, 'providerId': 'phone'})
+      fba.UserInfo.fromJson({..._user, 'providerId': 'password'}),
+      fba.UserInfo.fromJson({..._user, 'providerId': 'google.com'}),
+      fba.UserInfo.fromJson({..._user, 'providerId': 'apple.com'}),
+      fba.UserInfo.fromJson({..._user, 'providerId': 'phone'})
     ];
   }
 }
 
-class MockAuth extends Mock implements FirebaseAuth {
+class MockAuth extends Mock implements fba.FirebaseAuth {
   @override
-  User? get currentUser => MockUser();
+  fba.User? get currentUser => MockUser();
 }

--- a/tests/integration_test/firebase_ui_auth/phone_verification_test.dart
+++ b/tests/integration_test/firebase_ui_auth/phone_verification_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
@@ -157,7 +157,7 @@ void main() {
     testWidgets(
       'signs in if the code is correct',
       (tester) async {
-        final completer = Completer<User>();
+        final completer = Completer<fba.User>();
 
         await render(
           tester,

--- a/tests/integration_test/firebase_ui_auth/universal_email_sign_in_screen_test.dart
+++ b/tests/integration_test/firebase_ui_auth/universal_email_sign_in_screen_test.dart
@@ -4,8 +4,7 @@
 
 // ignore_for_file: deprecated_member_use
 
-import 'package:firebase_auth/firebase_auth.dart'
-    hide EmailAuthProvider, PhoneAuthProvider;
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -109,7 +108,7 @@ void main() {
 // ignore: avoid_implementing_value_types
 class MockApp extends Mock implements FirebaseApp {}
 
-class MockAuth extends Mock implements FirebaseAuth {
+class MockAuth extends Mock implements fba.FirebaseAuth {
   @override
   FirebaseApp get app => MockApp();
 

--- a/tests/integration_test/firebase_ui_oauth_apple/apple_sign_in_test.dart
+++ b/tests/integration_test/firebase_ui_oauth_apple/apple_sign_in_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_ui_oauth_apple/firebase_ui_oauth_apple.dart';
 import 'package:flutter/foundation.dart';
@@ -17,7 +17,7 @@ import '../utils.dart';
 
 void main() async {
   final provider = AppleProvider();
-  late FirebaseAuth auth;
+  late fba.FirebaseAuth auth;
   late MockProvider fbProvider;
 
   const labels = DefaultLocalizations();
@@ -141,7 +141,7 @@ class MockListener<T> extends Mock {
   }
 }
 
-class MockUser extends Mock implements User {
+class MockUser extends Mock implements fba.User {
   @override
   String? get displayName => 'Test User';
 
@@ -149,19 +149,19 @@ class MockUser extends Mock implements User {
   String? get email => 'test@test.com';
 }
 
-class MockCredential extends Mock implements UserCredential {
+class MockCredential extends Mock implements fba.UserCredential {
   @override
-  User? get user => MockUser();
+  fba.User? get user => MockUser();
 }
 
-class MockProvider extends Mock implements AppleAuthProvider {}
+class MockProvider extends Mock implements fba.AppleAuthProvider {}
 
 // ignore: avoid_implementing_value_types
 class MockApp extends Mock implements FirebaseApp {}
 
-class MockAuth extends Mock implements FirebaseAuth {
+class MockAuth extends Mock implements fba.FirebaseAuth {
   @override
-  Future<UserCredential> signInWithProvider(Object provider) async {
+  Future<fba.UserCredential> signInWithProvider(Object provider) async {
     return super.noSuchMethod(
       Invocation.method(#signInWithAuthProvider, [provider]),
       returnValue: Future.delayed(const Duration(milliseconds: 500)).then(

--- a/tests/integration_test/utils.dart
+++ b/tests/integration_test/utils.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_ui_firestore/firebase_ui_firestore.dart';
 import 'package:flutter/foundation.dart';
@@ -29,7 +29,7 @@ bool get isMobile {
 }
 
 late FirebaseFirestore db;
-late FirebaseAuth auth;
+late fba.FirebaseAuth auth;
 
 bool _prepared = false;
 
@@ -42,8 +42,8 @@ Future<void> prepare() async {
   }
 
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-  await FirebaseAuth.instance.useAuthEmulator('localhost', 9098);
-  auth = FirebaseAuth.instance;
+  await fba.FirebaseAuth.instance.useAuthEmulator('localhost', 9098);
+  auth = fba.FirebaseAuth.instance;
 
   FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
   db = FirebaseFirestore.instance;

--- a/tests/windows/flutter/generated_plugin_registrant.cc
+++ b/tests/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <desktop_webview_auth/desktop_webview_auth_plugin.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  CloudFirestorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
   DesktopWebviewAuthPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopWebviewAuthPlugin"));
   FirebaseAuthPluginCApiRegisterWithRegistrar(

--- a/tests/windows/flutter/generated_plugins.cmake
+++ b/tests/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  cloud_firestore
   desktop_webview_auth
   firebase_auth
   firebase_core


### PR DESCRIPTION
Recent version of firebase_auth exported a class named AuthProvider. This made Firebase UI incompatible with the latest version of the Firebase Auth, because of the name conflict (AuthProvider already existed in Firebase UI).

This change is intended to prevent such conflicts in future.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
