### PR TITLE
fix: null exception when header rebuid during logout

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -802,7 +802,7 @@ class ProfileScreen extends MultiProviderScreen {
     final mfaScopeKey = RebuildScopeKey();
     final emailVerificationScopeKey = RebuildScopeKey();
 
-    final user = auth.currentUser!;
+    final user = auth.currentUser;
 
     final avatarWidget = avatar ??
         Align(
@@ -819,10 +819,10 @@ class ProfileScreen extends MultiProviderScreen {
       children: [
         avatarWidget,
         Align(child: EditableUserDisplayName(auth: auth)),
-        if (!user.emailVerified) ...[
+        if (user?.emailVerified == false) ...[
           RebuildScope(
             builder: (context) {
-              if (user.emailVerified) {
+              if (user?.emailVerified == true) {
                 return const SizedBox.shrink();
               }
 
@@ -836,10 +836,15 @@ class ProfileScreen extends MultiProviderScreen {
         ],
         RebuildScope(
           builder: (context) {
-            final user = auth.currentUser!;
-            final linkedProviders = getLinkedProviders(user);
+            final user = auth.currentUser;
+            final List<AuthProvider<AuthListener, fba.AuthCredential>>? linkedProviders;
+            if (user != null) {
+              linkedProviders = getLinkedProviders(user);
+            } else {
+              linkedProviders = null;
+            }
 
-            if (linkedProviders.isEmpty) {
+            if (linkedProviders == null || linkedProviders.isEmpty) {
               return const SizedBox.shrink();
             }
 
@@ -857,10 +862,15 @@ class ProfileScreen extends MultiProviderScreen {
         ),
         RebuildScope(
           builder: (context) {
-            final user = auth.currentUser!;
-            final availableProviders = getAvailableProviders(context, user);
+            final user = auth.currentUser;
+            final List<AuthProvider<AuthListener, fba.AuthCredential>>? availableProviders;
+            if (user != null) {
+              availableProviders = getAvailableProviders(context, user);
+            } else {
+              availableProviders = null;
+            }
 
-            if (availableProviders.isEmpty) {
+            if (availableProviders == null || availableProviders.isEmpty) {
               return const SizedBox.shrink();
             }
 
@@ -878,8 +888,17 @@ class ProfileScreen extends MultiProviderScreen {
         if (showMFATile)
           RebuildScope(
             builder: (context) {
-              final user = auth.currentUser!;
-              final mfa = user.multiFactor;
+              final user = auth.currentUser;
+              final fba.MultiFactor? mfa;
+              if (user != null) {
+                mfa = user.multiFactor;
+              } else {
+                mfa = null;
+              }
+
+              if (mfa == null) {
+                return const SizedBox.shrink();
+              }
 
               return FutureBuilder<List<fba.MultiFactorInfo>>(
                 future: mfa.getEnrolledFactors(),


### PR DESCRIPTION
## Description

Fixed null exception.

When user define a custom avatar of the ProfileScreen which listen property of Firebase current user, the logout will trigger the rebuild of this custom avatar widget and the rebuild of ProfileScreen few time before ProfileScreen can be pop.

Actual code FORCE null safety.... 

Please review and merge.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
