### PR TITLE
feat(ui_auth): confirm account deletion

### DIFF
--- a/packages/firebase_ui_auth/example/lib/main.dart
+++ b/packages/firebase_ui_auth/example/lib/main.dart
@@ -269,6 +269,7 @@ class FirebaseAuthUIExample extends StatelessWidget {
                 platform == TargetPlatform.iOS ||
                 platform == TargetPlatform.android,
             showUnlinkConfirmationDialog: true,
+            showDeleteConfirmationDialog: true,
           );
         },
       },

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -738,6 +738,9 @@ class ProfileScreen extends MultiProviderScreen {
   /// tries to unlink a provider.
   final bool showUnlinkConfirmationDialog;
 
+  /// {@macro ui.auth.widgets.delete_account_button.show_delete_confirmation_dialog}
+  final bool showDeleteConfirmationDialog;
+
   const ProfileScreen({
     super.key,
     super.auth,
@@ -753,6 +756,7 @@ class ProfileScreen extends MultiProviderScreen {
     this.actionCodeSettings,
     this.showMFATile = false,
     this.showUnlinkConfirmationDialog = false,
+    this.showDeleteConfirmationDialog = false,
   });
 
   Future<bool> _reauthenticate(BuildContext context) {
@@ -913,6 +917,7 @@ class ProfileScreen extends MultiProviderScreen {
         const SizedBox(height: 8),
         DeleteAccountButton(
           auth: auth,
+          showDeleteConfirmationDialog: showDeleteConfirmationDialog,
           onSignInRequired: () {
             return _reauthenticate(context);
           },

--- a/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
@@ -58,6 +58,11 @@ class DeleteAccountButton extends StatefulWidget {
   /// {@macro ui.shared.widgets.button_variant}
   final ButtonVariant variant;
 
+  /// {@template ui.auth.widgets.delete_account_button.show_delete_confirmation_dialog}
+  /// If `true`, the user will be asked to confirm the account deletion.
+  /// {@endtemplate}
+  final bool showDeleteConfirmationDialog;
+
   /// {@macro ui.auth.widgets.delete_account_button}
   const DeleteAccountButton({
     super.key,
@@ -65,6 +70,7 @@ class DeleteAccountButton extends StatefulWidget {
     this.onSignInRequired,
     this.onDeleteFailed,
     this.variant = ButtonVariant.filled,
+    this.showDeleteConfirmationDialog = false,
   });
 
   @override
@@ -76,7 +82,31 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
   fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
   bool _isLoading = false;
 
+  void Function() pop<T>(T result) => () => Navigator.of(context).pop(result);
+
   Future<void> _deleteAccount() async {
+    bool? confirmed = !widget.showDeleteConfirmationDialog;
+
+    if (!confirmed) {
+      final l = FirebaseUILocalizations.labelsOf(context);
+
+      confirmed = await showCupertinoDialog<bool?>(
+        context: context,
+        builder: (context) {
+          return UniversalAlert(
+            onConfirm: pop(true),
+            onCancel: pop(false),
+            title: l.confirmDeleteAccountAlertTitle,
+            confirmButtonText: l.confirmDeleteAccountButtonLabel,
+            cancelButtonText: l.cancelButtonLabel,
+            message: l.confirmDeleteAccountAlertMessage,
+          );
+        },
+      );
+    }
+
+    if (!(confirmed ?? false)) return;
+
     setState(() {
       _isLoading = true;
     });

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ar.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ar.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "ar",
-  "@@last_modified": "2023-10-12T15:27:44.517152",
+  "@@last_modified": "2023-11-16T00:26:53.958517",
   "accessDisabledErrorText": "تم إيقاف إذن الوصول إلى هذا الحساب مؤقتًا.",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_de.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_de.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "de",
-  "@@last_modified": "2023-10-12T15:27:44.513540",
+  "@@last_modified": "2023-11-16T00:26:53.960802",
   "accessDisabledErrorText": "Der Zugriff auf dieses Konto wurde vorübergehend gesperrt",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_en.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_en.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "en",
-  "@@last_modified": "2023-10-12T15:27:44.518427",
+  "@@last_modified": "2023-11-16T00:26:53.966433",
   "accessDisabledErrorText": "Access to this account has been temporarily disabled",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_es.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_es.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "es",
-  "@@last_modified": "2023-10-12T15:27:44.501153",
+  "@@last_modified": "2023-11-16T00:26:53.955942",
   "accessDisabledErrorText": "Se ha inhabilitado temporalmente al acceso a esta cuenta",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_es_419.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_es_419.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "es_419",
-  "@@last_modified": "2023-10-12T15:27:44.515829",
+  "@@last_modified": "2023-11-16T00:26:53.960081",
   "accessDisabledErrorText": "Se inhabilitó temporalmente el acceso a la cuenta",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_fr.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_fr.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "fr",
-  "@@last_modified": "2023-10-12T15:27:44.520556",
+  "@@last_modified": "2023-11-16T00:26:53.965799",
   "accessDisabledErrorText": "L'accès à ce compte a été temporairement désactivé",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_he.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_he.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "he",
-  "@@last_modified": "2023-10-12T15:27:44.509494",
+  "@@last_modified": "2023-11-16T00:26:53.957614",
   "accessDisabledErrorText": "הגישה לחשבון זה הושבתה באופן זמני",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_hi.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_hi.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "hi",
-  "@@last_modified": "2023-10-12T15:27:44.531280",
+  "@@last_modified": "2023-11-16T00:26:53.970972",
   "accessDisabledErrorText": "इस खाते के ऐक्सेस पर, कुछ समय के लिए रोक लगा दी गई है",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_hu.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_hu.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "hu",
-  "@@last_modified": "2023-10-12T15:27:44.527227",
+  "@@last_modified": "2023-11-16T00:26:53.935987",
   "accessDisabledErrorText": "A fiók átmenetileg le van tiltva",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_id.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_id.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "id",
-  "@@last_modified": "2023-10-12T15:27:44.525126",
+  "@@last_modified": "2023-11-16T00:26:53.947166",
   "accessDisabledErrorText": "Akses ke akun ini telah dinonaktifkan untuk sementara waktu",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_it.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_it.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "it",
-  "@@last_modified": "2023-10-12T15:27:44.529631",
+  "@@last_modified": "2023-11-16T00:26:53.959280",
   "accessDisabledErrorText": "L'accesso a questo account è stato temporaneamente disabilitato",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ja.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ja.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "ja",
-  "@@last_modified": "2023-10-12T15:27:44.526360",
+  "@@last_modified": "2023-11-16T00:26:53.969833",
   "accessDisabledErrorText": "このアカウントへのアクセスが一時的に無効になっています",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ko.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ko.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "ko",
-  "@@last_modified": "2023-10-12T15:27:44.523502",
+  "@@last_modified": "2023-11-16T00:26:53.951316",
   "accessDisabledErrorText": "이 계정의 액세스가 일시적으로 중지되었습니다.",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_nl.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_nl.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "nl",
-  "@@last_modified": "2023-10-12T15:27:44.530523",
+  "@@last_modified": "2023-11-16T00:26:53.968350",
   "accessDisabledErrorText": "De toegang tot dit account is tijdelijk uitgezet",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pl.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pl.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "pl",
-  "@@last_modified": "2023-10-12T15:27:44.532029",
+  "@@last_modified": "2023-11-16T00:26:53.969138",
   "accessDisabledErrorText": "Dostęp do tego konta został tymczasowo wyłączony",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pt.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pt.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "pt",
-  "@@last_modified": "2023-10-12T15:27:44.533657",
+  "@@last_modified": "2023-11-16T00:26:53.961567",
   "accessDisabledErrorText": "O acesso a esta conta foi desativado temporariamente",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ro.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ro.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "ro",
-  "@@last_modified": "2023-10-27T14:20:44.123456",
+  "@@last_modified": "2023-11-16T00:26:53.953074",
   "accessDisabledErrorText": "Accesul la acest cont a fost dezactivat temporar",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Parola trebuie să aibă cel puțin 6 caractere",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ru.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ru.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "ru",
-  "@@last_modified": "2023-10-12T15:27:44.532762",
+  "@@last_modified": "2023-11-16T00:26:53.970486",
   "accessDisabledErrorText": "Доступ к этому аккаунту временно заблокирован.",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_th.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_th.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "th",
-  "@@last_modified": "2023-10-12T15:27:44.528121",
+  "@@last_modified": "2023-11-16T00:26:53.962240",
   "accessDisabledErrorText": "มีการปิดใช้สิทธิ์เข้าถึงบัญชีนี้ชั่วคราว",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_tr.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_tr.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "tr",
-  "@@last_modified": "2023-10-12T15:27:44.528980",
+  "@@last_modified": "2023-11-16T00:26:53.965059",
   "accessDisabledErrorText": "Bu hesaba erişim geçici olarak devre dışı bırakıldı",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_uk.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_uk.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "uk",
-  "@@last_modified": "2023-10-12T15:27:44.522576",
+  "@@last_modified": "2023-11-16T00:26:53.963333",
   "accessDisabledErrorText": "Доступ до цього облікового запису тимчасово вимкнено",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_zh.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_zh.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "zh",
-  "@@last_modified": "2023-10-12T15:27:44.524372",
+  "@@last_modified": "2023-11-16T00:26:53.967302",
   "accessDisabledErrorText": "对此帐号的访问权限已被临时停用",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_zh_TW.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_zh_TW.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "zh_TW",
-  "@@last_modified": "2023-10-12T15:27:44.521552",
+  "@@last_modified": "2023-11-16T00:26:53.964324",
   "accessDisabledErrorText": "這個帳戶暫時無法存取",
   "@accessDisabledErrorText": {
     "description": "Used as an error message when account is blocked and user tries to perform some actions with the account (e.g. unlinking a credential).",
@@ -512,6 +512,21 @@
   "weakPasswordErrorText": "Password should be at least 6 characters",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "@confirmDeleteAccountAlertTitle": {
+    "description": "Delete account confirmation dialog title",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "@confirmDeleteAccountAlertMessage": {
+    "description": "Delete account confirmation dialog message",
+    "placeholders": {}
+  },
+  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "@confirmDeleteAccountButtonLabel": {
+    "description": "Confirm delete account button label",
     "placeholders": {}
   }
 }

--- a/packages/firebase_ui_localizations/lib/src/default_localizations.dart
+++ b/packages/firebase_ui_localizations/lib/src/default_localizations.dart
@@ -62,6 +62,15 @@ abstract class FirebaseUILocalizationLabels {
   /// Used as a label of the country code picker dropdown.
   String get chooseACountry;
 
+  /// Delete account confirmation dialog message
+  String get confirmDeleteAccountAlertMessage;
+
+  /// Delete account confirmation dialog title
+  String get confirmDeleteAccountAlertTitle;
+
+  /// Confirm delete account button label
+  String get confirmDeleteAccountButtonLabel;
+
   /// Used as an error text when provided passwords do not match.
   String get confirmPasswordDoesNotMatchErrorText;
 
@@ -287,7 +296,7 @@ abstract class FirebaseUILocalizationLabels {
   String get ulinkProviderAlertTitle;
 
   /// Used as a generic error message when unable to resolve error details from
-  /// Exception or fba.FirebaseAuthException.
+  /// Exception or FirebaseAuthException.
   String get unknownError;
 
   /// Text that is shown as a message of the AlertDialog confirming provider

--- a/packages/firebase_ui_localizations/lib/src/lang/ar.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ar.dart
@@ -330,4 +330,14 @@ class ArLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/de.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/de.dart
@@ -327,4 +327,14 @@ class DeLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/en.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/en.dart
@@ -323,4 +323,14 @@ class EnLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/es.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/es.dart
@@ -332,4 +332,14 @@ class EsLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/es_419.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/es_419.dart
@@ -329,4 +329,14 @@ class Es419Localizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/fr.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/fr.dart
@@ -333,4 +333,14 @@ class FrLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/he.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/he.dart
@@ -323,4 +323,14 @@ class HeLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/hi.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/hi.dart
@@ -326,4 +326,14 @@ class HiLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/hu.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/hu.dart
@@ -324,4 +324,14 @@ class HuLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/id.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/id.dart
@@ -324,4 +324,14 @@ class IdLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/it.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/it.dart
@@ -327,4 +327,14 @@ class ItLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/ja.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ja.dart
@@ -320,4 +320,14 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/ko.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ko.dart
@@ -318,4 +318,14 @@ class KoLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/nl.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/nl.dart
@@ -326,4 +326,14 @@ class NlLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/pl.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/pl.dart
@@ -326,4 +326,14 @@ class PlLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/pt.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/pt.dart
@@ -327,4 +327,14 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/ro.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ro.dart
@@ -328,4 +328,14 @@ class RoLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Parola trebuie să aibă cel puțin 6 caractere";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/ru.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ru.dart
@@ -326,4 +326,14 @@ class RuLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/th.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/th.dart
@@ -323,4 +323,14 @@ class ThLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/tr.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/tr.dart
@@ -326,4 +326,14 @@ class TrLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/uk.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/uk.dart
@@ -328,4 +328,14 @@ class UkLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/zh.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/zh.dart
@@ -316,4 +316,14 @@ class ZhLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/zh_tw.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/zh_tw.dart
@@ -316,4 +316,14 @@ class ZhTWLocalizations extends FirebaseUILocalizationLabels {
   @override
   String get weakPasswordErrorText =>
       "Password should be at least 6 characters";
+
+  @override
+  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+
+  @override
+  String get confirmDeleteAccountAlertMessage =>
+      "Are you sure you want to delete your account?";
+
+  @override
+  String get confirmDeleteAccountButtonLabel => "Yes, delete";
 }


### PR DESCRIPTION
`ProfileScreen` and `DeleteAccountButton` now have `showDeleteConfirmationDialog`. If set to true, user will be presented a dialog asking to confirm this action.

## Related Issues

Closes #40

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
