### PR TITLE
feat(ui_storage)!: upgrade uuid dependency to ^4.0.0

### DIFF
--- a/packages/firebase_ui_storage/lib/src/config.dart
+++ b/packages/firebase_ui_storage/lib/src/config.dart
@@ -5,6 +5,7 @@
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as path;
+import 'package:uuid/data.dart';
 import 'package:uuid/uuid.dart';
 
 import 'lib.dart';
@@ -27,7 +28,7 @@ abstract class FileUploadNamingPolicy {
   factory FileUploadNamingPolicy.keepPath() => const KeepPathUploadPolicy();
 
   /// Creates a [UuidFileUploadNamingPolicy]
-  factory FileUploadNamingPolicy.uuid([Map<String, String>? options]) {
+  factory FileUploadNamingPolicy.uuid([V4Options? options]) {
     return UuidFileUploadNamingPolicy(options: options);
   }
 }
@@ -56,7 +57,7 @@ class KeepPathUploadPolicy implements FileUploadNamingPolicy {
 /// preserving file extension.
 class UuidFileUploadNamingPolicy implements FileUploadNamingPolicy {
   final Uuid uuid;
-  final Map<String, dynamic>? options;
+  final V4Options? options;
 
   const UuidFileUploadNamingPolicy({
     this.uuid = const Uuid(),
@@ -66,7 +67,7 @@ class UuidFileUploadNamingPolicy implements FileUploadNamingPolicy {
   @override
   String getUploadFileName(String fullPath) {
     final extension = path.extension(fullPath);
-    final name = uuid.v4(options: options);
+    final name = uuid.v4(config: options);
 
     return '$name$extension';
   }

--- a/packages/firebase_ui_storage/pubspec.yaml
+++ b/packages/firebase_ui_storage/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   firebase_ui_localizations: ^1.8.0
   firebase_ui_shared: ^1.4.1
   path: ^1.8.2
-  uuid: ^3.0.7
+  uuid: ^4.0.0
   file_selector: ^1.0.1
   flutter_blurhash: ^0.7.0
 

--- a/packages/firebase_ui_storage/test/mocks.dart
+++ b/packages/firebase_ui_storage/test/mocks.dart
@@ -4,6 +4,7 @@
 
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:mockito/mockito.dart';
+import 'package:uuid/data.dart';
 import 'package:uuid/uuid.dart';
 
 class MockReference extends Mock implements Reference {}
@@ -19,5 +20,5 @@ class MockUUID extends Mock implements Uuid {
   static String value = '1234-5678-9012-3456';
 
   @override
-  String v4({Map<String, dynamic>? options}) => value;
+  String v4({Map<String, dynamic>? options, V4Options? config}) => value;
 }


### PR DESCRIPTION
`UuidFileUploadNamingPolicy` and respective factory constructor `FileUploadNamingPolicy.uuid` now accept `V4Options?`, instead of `Map<String, dynamic>?`.

Here's an example migration:

```diff
final config = FirebaseUIStorageConfiguration(
  storage: storage,
-  namingPolicy: FileUploadNamingPolicy.uuid({ 'rng': CryptoRNG() }),
+  namingPolicy: FileUploadNamingPolicy.uuid(V4Options(null, CryptoRNG())),
);

await FirebaseUIStorage.configure(config);
```

## Related Issues

Requested in #176

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
