### PR TITLE
fix(ui_firestore): A value of type 'int?' can't be returned from a function with return type 'int' because 'int?

### DIFF
--- a/packages/firebase_ui_firestore/lib/src/table_builder.dart
+++ b/packages/firebase_ui_firestore/lib/src/table_builder.dart
@@ -871,7 +871,7 @@ class _Source extends DataTableSource {
 
   @override
   int get rowCount {
-    if (_aggregateSnapshot?.count != null) return _aggregateSnapshot!.count;
+    if (_aggregateSnapshot?.count != null) return _aggregateSnapshot!.count!;
     // Emitting an extra item during load or before reaching the end
     // allows the DataTable to show a spinner during load & let the user
     // navigate to next page


### PR DESCRIPTION
## Description

Fixes #239

## Related Issues

_Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/firebase/FirebaseUI-Flutter/issues). Indicate, which of these issues are resolved or fixed by this PR._

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
