### PR TITLE
chore: Revert "fix(ui_firestore): A value of type 'int?' can't be returned from a function with return type 'int' because 'int?"

### DIFF
--- a/packages/firebase_ui_firestore/lib/src/table_builder.dart
+++ b/packages/firebase_ui_firestore/lib/src/table_builder.dart
@@ -871,7 +871,7 @@ class _Source extends DataTableSource {
 
   @override
   int get rowCount {
-    if (_aggregateSnapshot?.count != null) return _aggregateSnapshot!.count!;
+    if (_aggregateSnapshot?.count != null) return _aggregateSnapshot!.count;
     // Emitting an extra item during load or before reaching the end
     // allows the DataTable to show a spinner during load & let the user
     // navigate to next page


### PR DESCRIPTION
Reverts firebase/FirebaseUI-Flutter#241