### PR TITLE
chore(firebase_ui_localizations): Copyright 2024

### DIFF
--- a/packages/firebase_ui_localizations/lib/src/default_localizations.dart
+++ b/packages/firebase_ui_localizations/lib/src/default_localizations.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/firebase_ui_localizations/lib/src/lang/ar.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ar.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/de.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/de.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/en.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/en.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/es.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/es.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/es_419.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/es_419.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/fr.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/fr.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/he.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/he.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/hi.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/hi.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/hu.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/hu.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/id.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/id.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/it.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/it.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/ja.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ja.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/ko.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ko.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/nb.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/nb.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/nl.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/nl.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/pl.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/pl.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/pt.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/pt.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/ro.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ro.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';
@@ -330,12 +330,12 @@ class RoLocalizations extends FirebaseUILocalizationLabels {
       "Parola trebuie să aibă cel puțin 6 caractere";
 
   @override
-  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+  String get confirmDeleteAccountAlertTitle => "Confirmă ștergerea contului";
 
   @override
   String get confirmDeleteAccountAlertMessage =>
-      "Are you sure you want to delete your account?";
+      "Ești sigur că vrei să îți ștergi contul?";
 
   @override
-  String get confirmDeleteAccountButtonLabel => "Yes, delete";
+  String get confirmDeleteAccountButtonLabel => "Da, șterge";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/ru.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ru.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/th.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/th.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/tr.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/tr.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/uk.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/uk.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/zh.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/zh.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/zh_tw.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/zh_tw.dart
@@ -1,4 +1,4 @@
-// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';


### PR DESCRIPTION
## Description

I executed `dart run firebase_ui_localizations:gen_l10n` and Copyright has been updated.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
