### PR TITLE
fix: Arabic translation of Sign In With Apple button label

### DIFF
--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ar.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ar.arb
@@ -309,7 +309,7 @@
     "description": "Used as a title of the LoginView when AuthAction is AuthAction.signIn.",
     "placeholders": {}
   },
-  "signInWithAppleButtonText": "تسجيل الدخول باستخدام حساب على Apple",
+  "signInWithAppleButtonText": "تسجيل الدخول باستخدام Apple",
   "@signInWithAppleButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Apple provider.",
     "placeholders": {}

--- a/packages/firebase_ui_localizations/lib/src/lang/ar.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ar.dart
@@ -197,8 +197,7 @@ class ArLocalizations extends FirebaseUILocalizationLabels {
   String get signInText => "تسجيل الدخول";
 
   @override
-  String get signInWithAppleButtonText =>
-      "تسجيل الدخول باستخدام حساب على Apple";
+  String get signInWithAppleButtonText => "تسجيل الدخول باستخدام Apple";
 
   @override
   String get signInWithEmailLinkSentText =>


### PR DESCRIPTION
## Description

Currently the label of the Sign In With Apple button in Arabic looks like the left image on a Pixel 6 Pro phone.  Apple rejects apps that look like this because it does not adhere to its design guidelines. The label overlaps with Apple logo and the phrase is different than Apple's translation. This PR is a simple fix to issue and the result can be seen below.

| Before | After |
|--------|------|
|![Screenshot_20240127_200930](https://github.com/firebase/FirebaseUI-Flutter/assets/23536606/59fe7f5a-667b-424e-9797-c4cd9ea324b0)|![Screenshot_20240127_203025](https://github.com/firebase/FirebaseUI-Flutter/assets/23536606/9b8e012d-2aa3-4ea7-bbad-ec9ea6438dcb)|


| Apple Design Guidelines |
|--------------------------|
|![Screenshot_20240127_203026](https://github.com/firebase/FirebaseUI-Flutter/assets/23536606/c78f1ae0-a9ab-4661-8452-ac04f9a16cc1)|

## Related Issues

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
