### PR TITLE
fix(firebase_ui_auth): actionsBeforeDelete callback

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -716,6 +716,9 @@ class ProfileScreen extends MultiProviderScreen {
   /// ```
   final List<FirebaseUIAction>? actions;
 
+  // Any actions that should be performed before the account is deleted.
+  final ActionsBeforeDeleteCallback? actionsBeforeDelete;
+
   /// See [Scaffold.appBar].
   final AppBar? appBar;
 
@@ -751,6 +754,7 @@ class ProfileScreen extends MultiProviderScreen {
     this.avatarSize,
     this.children = const [],
     this.actions,
+    this.actionsBeforeDelete,
     this.appBar,
     this.cupertinoNavigationBar,
     this.actionCodeSettings,
@@ -917,6 +921,7 @@ class ProfileScreen extends MultiProviderScreen {
         const SizedBox(height: 8),
         DeleteAccountButton(
           auth: auth,
+          actionsBeforeDelete: actionsBeforeDelete,
           showDeleteConfirmationDialog: showDeleteConfirmationDialog,
           onSignInRequired: () {
             return _reauthenticate(context);

--- a/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 
 typedef DeleteFailedCallback = void Function(Exception exception);
 typedef SignInRequiredCallback = Future<bool> Function();
+typedef ActionsBeforeDeleteCallback = Future<bool> Function();
 
 /// {@template ui.auth.widgets.delete_account_button}
 /// A button that triggers the deletion of the user's account.
@@ -55,6 +56,9 @@ class DeleteAccountButton extends StatefulWidget {
   /// A callback that is called if the account deletion fails.
   final DeleteFailedCallback? onDeleteFailed;
 
+  /// A callback that is called before the account is deleted.
+  final ActionsBeforeDeleteCallback? actionsBeforeDelete;
+
   /// {@macro ui.shared.widgets.button_variant}
   final ButtonVariant variant;
 
@@ -69,6 +73,7 @@ class DeleteAccountButton extends StatefulWidget {
     this.auth,
     this.onSignInRequired,
     this.onDeleteFailed,
+    this.actionsBeforeDelete,
     this.variant = ButtonVariant.filled,
     this.showDeleteConfirmationDialog = false,
   });
@@ -112,6 +117,13 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
     });
 
     try {
+      if (widget.actionsBeforeDelete != null) {
+        final proceed = await widget.actionsBeforeDelete!();
+        if (!proceed) {
+          throw Exception('Can not complete actions before delete.');
+        }
+      }
+
       final user = auth.currentUser!;
       await auth.currentUser?.delete();
 


### PR DESCRIPTION
## Description

Add actionsBeforeDelete callback to ProfileScreen and DeleteAccountButton

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
