### PR TITLE
flag to show/hide 'Sign-in methods'

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -754,6 +754,7 @@ class ProfileScreen extends MultiProviderScreen {
     this.appBar,
     this.cupertinoNavigationBar,
     this.actionCodeSettings,
+    this.showSignInMethods = true,
     this.showMFATile = false,
     this.showUnlinkConfirmationDialog = false,
     this.showDeleteConfirmationDialog = false,
@@ -859,26 +860,27 @@ class ProfileScreen extends MultiProviderScreen {
           },
           scopeKey: providersScopeKey,
         ),
-        RebuildScope(
-          builder: (context) {
-            final user = auth.currentUser!;
-            final availableProviders = getAvailableProviders(context, user);
-
-            if (availableProviders.isEmpty) {
-              return const SizedBox.shrink();
-            }
-
-            return Padding(
-              padding: const EdgeInsets.only(top: 32),
-              child: _AvailableProvidersRow(
-                auth: auth,
-                providers: availableProviders,
-                onProviderLinked: providersScopeKey.rebuild,
-              ),
-            );
-          },
-          scopeKey: providersScopeKey,
-        ),
+        if (showSignInMethods)
+            RebuildScope(
+              builder: (context) {
+                final user = auth.currentUser!;
+                final availableProviders = getAvailableProviders(context, user);
+    
+                if (availableProviders.isEmpty) {
+                  return const SizedBox.shrink();
+                }
+    
+                return Padding(
+                  padding: const EdgeInsets.only(top: 32),
+                  child: _AvailableProvidersRow(
+                    auth: auth,
+                    providers: availableProviders,
+                    onProviderLinked: providersScopeKey.rebuild,
+                  ),
+                );
+              },
+              scopeKey: providersScopeKey,
+            ),
         if (showMFATile)
           RebuildScope(
             builder: (context) {


### PR DESCRIPTION
Add flag to allow show/hiding of the 'Sign-in methods' section which shows availableProviders

## Description

Would like to use ProfileScreen out of the box with flexibility to hide the Sign-in methods section

## Related Issues

n/a

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- x[ ] All existing and new tests are passing.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x ] I read and followed the [Flutter Style Guide].
- [x ] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
