### PR TITLE
feat(firebase_ui_auth): add `showPasswordVisibilityToggle` to `RegisterScreen`

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/register_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/register_screen.dart
@@ -87,6 +87,9 @@ class RegisterScreen extends MultiProviderScreen {
   /// * [EmailFormStyle]
   final Set<FirebaseUIStyle>? styles;
 
+  /// {@macro ui.auth.widgets.email_form.showPasswordVisibilityToggle}
+  final bool showPasswordVisibilityToggle;
+
   /// {@macro ui.auth.screens.responsive_page.max_width}
   final double? maxWidth;
 
@@ -107,6 +110,7 @@ class RegisterScreen extends MultiProviderScreen {
     this.footerBuilder,
     this.breakpoint = 800,
     this.styles,
+    this.showPasswordVisibilityToggle = false,
     this.maxWidth,
   });
 
@@ -130,6 +134,7 @@ class RegisterScreen extends MultiProviderScreen {
         subtitleBuilder: subtitleBuilder,
         footerBuilder: footerBuilder,
         breakpoint: breakpoint,
+        showPasswordVisibilityToggle: showPasswordVisibilityToggle,
         maxWidth: maxWidth,
       ),
     );

--- a/packages/firebase_ui_auth/test/screens/register_screen_test.dart
+++ b/packages/firebase_ui_auth/test/screens/register_screen_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group("$RegisterScreen", () {
+    setUpAll(() {
+      setFirebaseUiIsTestMode(true);
+    });
+
+    testWidgets(
+      "doesn't have password visibility toggle by default",
+      (tester) async {
+        await tester.pumpWidget(
+          TestMaterialApp(
+            child: RegisterScreen(
+              auth: MockAuth(),
+              providers: [EmailAuthProvider()],
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.visibility), findsNothing);
+      },
+    );
+
+    testWidgets('allows to add password visibility toggle', (tester) async {
+      await tester.pumpWidget(
+        TestMaterialApp(
+          child: RegisterScreen(
+            auth: MockAuth(),
+            providers: [EmailAuthProvider()],
+            showPasswordVisibilityToggle: true,
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.visibility), findsNWidgets(2));
+    });
+  });
+}


### PR DESCRIPTION
## Description

Currently, `showPasswordVisibilityToggle` is available on SignInScreen, but not on RegisterScreen. 

## Related Issues

#114

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
