### PR TITLE
fix(ui_localizations): In the Japanese file, change "login" to "sign and improve translations

### DIFF
--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ja.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ja.arb
@@ -51,7 +51,7 @@
     "description": "Used as a placeholder of the country code input.",
     "placeholders": {}
   },
-  "credentialAlreadyInUseErrorText": "このプロバイダは、すでに別のユーザー アカウントに関連付けられています。",
+  "credentialAlreadyInUseErrorText": "このプロバイダは、すでに別のユーザーアカウントに関連付けられています。",
   "@credentialAlreadyInUseErrorText": {
     "description": "Error text that is show when user tries to use an OAuth provider that doesn't belong to currently signed in user account.",
     "placeholders": {}
@@ -175,7 +175,7 @@
     "description": "",
     "placeholders": {}
   },
-  "mfaTitle": "2 段階認証プロセス",
+  "mfaTitle": "2段階認証プロセス",
   "@mfaTitle": {
     "description": "2-step verification settings tile title.",
     "placeholders": {}
@@ -309,7 +309,7 @@
     "description": "Used as a title of the LoginView when AuthAction is AuthAction.signIn.",
     "placeholders": {}
   },
-  "signInWithAppleButtonText": "Apple でサインイン",
+  "signInWithAppleButtonText": "Appleでサインイン",
   "@signInWithAppleButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Apple provider.",
     "placeholders": {}
@@ -324,12 +324,12 @@
     "description": "Used as a title on the EmailLinkSignInView.",
     "placeholders": {}
   },
-  "signInWithFacebookButtonText": "Facebook でサインイン",
+  "signInWithFacebookButtonText": "Facebookでサインイン",
   "@signInWithFacebookButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Facebook provider.",
     "placeholders": {}
   },
-  "signInWithGoogleButtonText": "Google でサインイン",
+  "signInWithGoogleButtonText": "Googleでサインイン",
   "@signInWithGoogleButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Google provider.",
     "placeholders": {}
@@ -339,7 +339,7 @@
     "description": "Used as a label of the PhoneVerificationButton.",
     "placeholders": {}
   },
-  "signInWithTwitterButtonText": "Twitter でサインイン",
+  "signInWithTwitterButtonText": "Twitterでサインイン",
   "@signInWithTwitterButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Twitter provider.",
     "placeholders": {}
@@ -349,7 +349,7 @@
     "description": "Used as a label of the SignOutButton.",
     "placeholders": {}
   },
-  "smsAutoresolutionFailedError": "SMS コードを自動で解決できませんでした。コードを手動で入力してください",
+  "smsAutoresolutionFailedError": "SMSコードを自動で解決できませんでした。コードを手動で入力してください",
   "@smsAutoresolutionFailedError": {
     "description": "Used as an error text when AutoresolutionFailedException is being thrown.",
     "placeholders": {}
@@ -399,7 +399,7 @@
     "description": "Used as a label of the submit button of the SMSCodeInputView.",
     "placeholders": {}
   },
-  "verifyingSMSCodeText": "SMS コードを確認しています...",
+  "verifyingSMSCodeText": "SMSコードを確認しています...",
   "@verifyingSMSCodeText": {
     "description": "Used as a status text of the SMSCodeInput when code verification is in progress.",
     "placeholders": {}

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ja.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_ja.arb
@@ -61,7 +61,7 @@
     "description": "Used as a label of the DeleteAccountButton.",
     "placeholders": {}
   },
-  "differentMethodsSignInTitleText": "次のいずれかの方法を使用してログインします",
+  "differentMethodsSignInTitleText": "次のいずれかの方法を使用してサインインします",
   "@differentMethodsSignInTitleText": {
     "description": "Used as a title of the dialog that indicates that there are different available sign in methods for a provided email.",
     "placeholders": {}
@@ -86,7 +86,7 @@
     "description": "Used as an error text of the EmailInput when the email is empty.",
     "placeholders": {}
   },
-  "emailLinkSignInButtonLabel": "マジックリンクでログイン",
+  "emailLinkSignInButtonLabel": "マジックリンクでサインイン",
   "@emailLinkSignInButtonLabel": {
     "description": "Used as a label of the EmailLinkSignInButton.",
     "placeholders": {}
@@ -101,7 +101,7 @@
     "description": "Button label that suggests to enable 2FA",
     "placeholders": {}
   },
-  "enableMoreSignInMethods": "その他のログイン方法を有効にします",
+  "enableMoreSignInMethods": "その他のサインイン方法を有効にします",
   "@enableMoreSignInMethods": {
     "description": "Used as a hint to connect more providers.",
     "placeholders": {}
@@ -289,7 +289,7 @@
     "description": "Used as a label of the submit button on the EmailLinkSignInView.",
     "placeholders": {}
   },
-  "signInActionText": "ログイン",
+  "signInActionText": "サインイン",
   "@signInActionText": {
     "description": "Used as a label of the EmailForm submit button when the AuthAction is AuthAction.signIn.",
     "placeholders": {}
@@ -299,12 +299,12 @@
     "description": "Used as a hint text of the LoginView suggesting to sign in instead of registering a new account.",
     "placeholders": {}
   },
-  "signInMethods": "ログイン方法",
+  "signInMethods": "サインイン方法",
   "@signInMethods": {
     "description": "Used as a label of the row showing connected providers.",
     "placeholders": {}
   },
-  "signInText": "ログイン",
+  "signInText": "サインイン",
   "@signInText": {
     "description": "Used as a title of the LoginView when AuthAction is AuthAction.signIn.",
     "placeholders": {}
@@ -314,32 +314,32 @@
     "description": "Used as a label of the OAuthProviderButton for Apple provider.",
     "placeholders": {}
   },
-  "signInWithEmailLinkSentText": "マジックリンクをメールでお送りしました。メールを確認し、リンクを使用してログインしてください",
+  "signInWithEmailLinkSentText": "マジックリンクをメールでお送りしました。メールを確認し、リンクを使用してサインインしてください",
   "@signInWithEmailLinkSentText": {
     "description": "Indicates that email with a sign in link was sent.",
     "placeholders": {}
   },
-  "signInWithEmailLinkViewTitleText": "マジックリンクでログイン",
+  "signInWithEmailLinkViewTitleText": "マジックリンクでサインイン",
   "@signInWithEmailLinkViewTitleText": {
     "description": "Used as a title on the EmailLinkSignInView.",
     "placeholders": {}
   },
-  "signInWithFacebookButtonText": "Facebook でログイン",
+  "signInWithFacebookButtonText": "Facebook でサインイン",
   "@signInWithFacebookButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Facebook provider.",
     "placeholders": {}
   },
-  "signInWithGoogleButtonText": "Google でログイン",
+  "signInWithGoogleButtonText": "Google でサインイン",
   "@signInWithGoogleButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Google provider.",
     "placeholders": {}
   },
-  "signInWithPhoneButtonText": "携帯電話を使用してログイン",
+  "signInWithPhoneButtonText": "携帯電話を使用してサインイン",
   "@signInWithPhoneButtonText": {
     "description": "Used as a label of the PhoneVerificationButton.",
     "placeholders": {}
   },
-  "signInWithTwitterButtonText": "Twitter でログイン",
+  "signInWithTwitterButtonText": "Twitter でサインイン",
   "@signInWithTwitterButtonText": {
     "description": "Used as a label of the OAuthProviderButton for Twitter provider.",
     "placeholders": {}

--- a/packages/firebase_ui_localizations/lib/src/lang/ja.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ja.dart
@@ -44,7 +44,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get deleteAccount => "アカウントを削除";
 
   @override
-  String get differentMethodsSignInTitleText => "次のいずれかの方法を使用してログインします";
+  String get differentMethodsSignInTitleText => "次のいずれかの方法を使用してサインインします";
 
   @override
   String get disable => "無効にする";
@@ -59,7 +59,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get emailIsRequiredErrorText => "メールアドレスは必須です";
 
   @override
-  String get emailLinkSignInButtonLabel => "マジックリンクでログイン";
+  String get emailLinkSignInButtonLabel => "マジックリンクでサインイン";
 
   @override
   String get emailTakenErrorText => "このようなメールアドレスを持つアカウントはすでに存在します";
@@ -68,7 +68,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get enable => "有効にする";
 
   @override
-  String get enableMoreSignInMethods => "その他のログイン方法を有効にします";
+  String get enableMoreSignInMethods => "その他のサインイン方法を有効にします";
 
   @override
   String get enterSMSCodeText => "SMS コードを入力";
@@ -178,38 +178,38 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get sendLinkButtonLabel => "マジックリンクで送信";
 
   @override
-  String get signInActionText => "ログイン";
+  String get signInActionText => "サインイン";
 
   @override
   String get signInHintText => "すでにアカウントをお持ちの場合";
 
   @override
-  String get signInMethods => "ログイン方法";
+  String get signInMethods => "サインイン方法";
 
   @override
-  String get signInText => "ログイン";
+  String get signInText => "サインイン";
 
   @override
   String get signInWithAppleButtonText => "Apple でサインイン";
 
   @override
   String get signInWithEmailLinkSentText =>
-      "マジックリンクをメールでお送りしました。メールを確認し、リンクを使用してログインしてください";
+      "マジックリンクをメールでお送りしました。メールを確認し、リンクを使用してサインインしてください";
 
   @override
-  String get signInWithEmailLinkViewTitleText => "マジックリンクでログイン";
+  String get signInWithEmailLinkViewTitleText => "マジックリンクでサインイン";
 
   @override
-  String get signInWithFacebookButtonText => "Facebook でログイン";
+  String get signInWithFacebookButtonText => "Facebook でサインイン";
 
   @override
-  String get signInWithGoogleButtonText => "Google でログイン";
+  String get signInWithGoogleButtonText => "Google でサインイン";
 
   @override
-  String get signInWithPhoneButtonText => "携帯電話を使用してログイン";
+  String get signInWithPhoneButtonText => "携帯電話を使用してサインイン";
 
   @override
-  String get signInWithTwitterButtonText => "Twitter でログイン";
+  String get signInWithTwitterButtonText => "Twitter でサインイン";
 
   @override
   String get signOutButtonText => "ログアウト";

--- a/packages/firebase_ui_localizations/lib/src/lang/ja.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ja.dart
@@ -38,7 +38,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
 
   @override
   String get credentialAlreadyInUseErrorText =>
-      "このプロバイダは、すでに別のユーザー アカウントに関連付けられています。";
+      "このプロバイダは、すでに別のユーザーアカウントに関連付けられています。";
 
   @override
   String get deleteAccount => "アカウントを削除";
@@ -71,7 +71,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get enableMoreSignInMethods => "その他のサインイン方法を有効にします";
 
   @override
-  String get enterSMSCodeText => "SMS コードを入力";
+  String get enterSMSCodeText => "SMSコードを入力";
 
   @override
   String get findProviderForEmailTitleText => "メールアドレスを入力して続行";
@@ -111,7 +111,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get mapLabel => "地図";
 
   @override
-  String get mfaTitle => "2 段階認証プロセス";
+  String get mfaTitle => "2段階認証プロセス";
 
   @override
   String get name => "名前";
@@ -190,7 +190,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get signInText => "サインイン";
 
   @override
-  String get signInWithAppleButtonText => "Apple でサインイン";
+  String get signInWithAppleButtonText => "Appleでサインイン";
 
   @override
   String get signInWithEmailLinkSentText =>
@@ -200,16 +200,16 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get signInWithEmailLinkViewTitleText => "マジックリンクでサインイン";
 
   @override
-  String get signInWithFacebookButtonText => "Facebook でサインイン";
+  String get signInWithFacebookButtonText => "Facebookでサインイン";
 
   @override
-  String get signInWithGoogleButtonText => "Google でサインイン";
+  String get signInWithGoogleButtonText => "Googleでサインイン";
 
   @override
   String get signInWithPhoneButtonText => "携帯電話を使用してサインイン";
 
   @override
-  String get signInWithTwitterButtonText => "Twitter でサインイン";
+  String get signInWithTwitterButtonText => "Twitterでサインイン";
 
   @override
   String get signOutButtonText => "ログアウト";
@@ -246,7 +246,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get verifyCodeButtonText => "確認";
 
   @override
-  String get verifyingSMSCodeText => "SMS コードを確認しています...";
+  String get verifyingSMSCodeText => "SMSコードを確認しています...";
 
   @override
   String get verifyItsYouText => "ご本人確認";


### PR DESCRIPTION
## Description

* In the Japanese translation file, "Login" and "Sign in" are mixed, so I unified them with "Sign in" to match the English version.
  * There may be some debate as to whether to use "Login" or "Sign In" for this, but I decided to go with the English version.
* Removed unnatural spaces in Japanese.

> * 日本語翻訳ファイルにおいて、「ログイン」と「サインイン」が混在しているので、英語版に合わせて「サインイン」に統一しました。
>   * 「ログイン」と「サインイン」のどちらを使うべきかには議論があるかもしれませんが、英語版に合わせることにしました。
> * 日本語の不自然な空白を削除しました。

## Related Issues

none

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
