### PR TITLE
fix(firebase_ui_auth): `sendPasswordResetEmail` should not be executed when `isLoading=true`

### DIFF
--- a/packages/firebase_ui_auth/lib/src/views/forgot_password_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/forgot_password_view.dart
@@ -54,6 +54,10 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
   fba.FirebaseAuthException? exception;
 
   Future<void> _submit(String email) async {
+    if (isLoading) {
+      return;
+    }
+
     setState(() {
       exception = null;
       isLoading = true;

--- a/packages/firebase_ui_auth/test/views/forgot_password_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/forgot_password_view_test.dart
@@ -88,18 +88,18 @@ void main() {
     );
 
     testWidgets("doesn't sendPasswordResetEmail on loading", (tester) async {
-        await tester.pumpWidget(widget);
+      await tester.pumpWidget(widget);
 
-        final input = find.byType(TextField);
-        await tester.enterText(input, 'delay@email.com');
-        
-        final button = find.byType(LoadingButton);
-        await tester.tap(button);
-        await tester.tap(button);
-        await tester.pumpAndSettle();
+      final input = find.byType(TextField);
+      await tester.enterText(input, 'delay@email.com');
 
-        expect(find.byType(ErrorText), findsNothing);
-        verify(auth.sendPasswordResetEmail(email:'delay@email.com')).called(1);
+      final button = find.byType(LoadingButton);
+      await tester.tap(button);
+      await tester.tap(button);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ErrorText), findsNothing);
+      verify(auth.sendPasswordResetEmail(email: 'delay@email.com')).called(1);
     });
   });
 }

--- a/packages/firebase_ui_auth/test/views/forgot_password_view_test.dart
+++ b/packages/firebase_ui_auth/test/views/forgot_password_view_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:firebase_auth/firebase_auth.dart' as fba;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -53,6 +54,10 @@ void main() {
       when(auth.sendPasswordResetEmail(email: 'valid@email.com')).thenAnswer(
         (_) => Future.value(),
       );
+
+      when(auth.sendPasswordResetEmail(email: 'delay@email.com')).thenAnswer(
+        (_) => Future.delayed(const Duration(milliseconds: 200)),
+      );
     });
 
     testWidgets('shows error if sendPasswordResetEmail failed', (tester) async {
@@ -81,5 +86,20 @@ void main() {
         expect(find.byType(ErrorText), findsNothing);
       },
     );
+
+    testWidgets("doesn't sendPasswordResetEmail on loading", (tester) async {
+        await tester.pumpWidget(widget);
+
+        final input = find.byType(TextField);
+        await tester.enterText(input, 'delay@email.com');
+        
+        final button = find.byType(LoadingButton);
+        await tester.tap(button);
+        await tester.tap(button);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ErrorText), findsNothing);
+        verify(auth.sendPasswordResetEmail(email:'delay@email.com')).called(1);
+    });
   });
 }


### PR DESCRIPTION
## Description

Even when ForgotPasswordView has isLoading=true,  `sendPasswordResetEmail` is executed the number of times the button is pressed.
I don't see any advantage for users to receive more than one email.

In this PR, if isLoading is true, the mail is not sent.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
