### PR TITLE
fix(ui_auth): Fixed a momentary form display after signing in with EmailLinkAuth.

### DIFF
--- a/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
@@ -45,18 +45,23 @@ class _EmailLinkSignInViewState extends State<EmailLinkSignInView> {
   Widget build(BuildContext context) {
     final l = FirebaseUILocalizations.labelsOf(context);
     final formKey = GlobalKey<FormState>();
+    const statesToHideForm = [
+      AwaitingDynamicLink,
+      SigningIn,
+    ];
 
     return AuthFlowBuilder<EmailLinkAuthController>(
       auth: widget.auth,
       provider: widget.provider,
       builder: (context, state, ctrl, child) {
+        final isFormHidden = statesToHideForm.contains(state.runtimeType);
         return Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Title(text: l.signInWithEmailLinkViewTitleText),
             const SizedBox(height: 16),
-            if (state is! AwaitingDynamicLink)
+            if (!isFormHidden)
               Form(
                 key: formKey,
                 child: EmailInput(
@@ -74,7 +79,7 @@ class _EmailLinkSignInViewState extends State<EmailLinkSignInView> {
               Text(l.signInWithEmailLinkSentText),
               const SizedBox(height: 16),
             ],
-            if (state is! AwaitingDynamicLink) ...[
+            if (!isFormHidden) ...[
               const SizedBox(height: 8),
               LoadingButton(
                 isLoading: state is SendingLink,


### PR DESCRIPTION
## Description

Fixed an issue where the email address input form was briefly redisplayed upon completing sign-in with EmailLinkAuth.

For now, I've prevented it from going back to the form display, but showing a loading indicator might also be a good idea.

## Related Issues

none

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
