### PR TITLE
fix(firebase_ui_auth): Use widget.email in ForgotPasswordScreen

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
@@ -283,7 +283,7 @@ class _SignInFormContentState extends State<_SignInFormContent> {
               } else {
                 showForgotPasswordScreen(
                   context: context,
-                  email: emailCtrl.text,
+                  email: widget.email ?? emailCtrl.text,
                   auth: widget.auth,
                 );
               }


### PR DESCRIPTION
## Description

When `EmailForm` calls `showForgotPasswordScreen`, the email address entered in `EmailInput` is used as the default value.
However, if `EmailForm` has email as field, an empty string will be used as the default value.

I have not written a test yet because of the difficulty in creating a mock `showForgotPasswordScreen`. Is there a good way to do this?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
