### PR TITLE
fix(auth): `ForgotPasswordScreen` display email within input box

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
@@ -277,13 +277,14 @@ class _SignInFormContentState extends State<_SignInFormContent> {
             onPressed: () {
               final navAction =
                   FirebaseUIAction.ofType<ForgotPasswordAction>(context);
+              final email = widget.email ?? emailCtrl.text;
 
               if (navAction != null) {
-                navAction.callback(context, emailCtrl.text);
+                navAction.callback(context, email);
               } else {
                 showForgotPasswordScreen(
                   context: context,
-                  email: emailCtrl.text,
+                  email: email,
                   auth: widget.auth,
                 );
               }


### PR DESCRIPTION
## Description

If we set the `email` property like below:

```dart
SignInScreen(
            email: 'some@email.com',
            actions: [
              ForgotPasswordAction((context, email) {
                Navigator.pushNamed(
                  context,
                  '/forgot-password',
                  arguments: {'email': email},
                );
              }),
// Rest of setup
```

We should see it in the `ForgotPasswordScreen`. Now, it displays correctly:
<img width="411" alt="Screenshot 2024-04-24 at 13 50 31" src="https://github.com/firebase/FirebaseUI-Flutter/assets/16018629/103b5e4d-4f6f-4459-9921-578761fa700f">

If we don't, it will still work as previously taking the value from the email input from sign-in screen.


## Related Issues

_Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/firebase/FirebaseUI-Flutter/issues). Indicate, which of these issues are resolved or fixed by this PR._

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
