### PR TITLE
fix(ui_auth): fix confirmation dialog for delete account button

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
@@ -82,7 +82,7 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
   fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
   bool _isLoading = false;
 
-  void Function() pop<T>(T result) => () => Navigator.of(context).pop(result);
+  void Function() pop<T>(BuildContext context, T result) => () => Navigator.of(context).pop(result);
 
   Future<void> _deleteAccount() async {
     bool? confirmed = !widget.showDeleteConfirmationDialog;
@@ -94,8 +94,8 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
         context: context,
         builder: (context) {
           return UniversalAlert(
-            onConfirm: pop(true),
-            onCancel: pop(false),
+            onConfirm: pop(context, true),
+            onCancel: pop(context, false),
             title: l.confirmDeleteAccountAlertTitle,
             confirmButtonText: l.confirmDeleteAccountButtonLabel,
             cancelButtonText: l.cancelButtonLabel,

--- a/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
@@ -82,7 +82,8 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
   fba.FirebaseAuth get auth => widget.auth ?? fba.FirebaseAuth.instance;
   bool _isLoading = false;
 
-  void Function() pop<T>(BuildContext context, T result) => () => Navigator.of(context).pop(result);
+  void Function() pop<T>(BuildContext context, T result) =>
+      () => Navigator.of(context).pop(result);
 
   Future<void> _deleteAccount() async {
     bool? confirmed = !widget.showDeleteConfirmationDialog;


### PR DESCRIPTION
## Description

previously the wrong navigator was popped when cancelling or confirming the dialog. this resulted in the dialog still beeing visible and the navigator behind it beeing popped. the fix adds the context object to the function parameter, so the right navigator gets popped.

## Related Issues

fixes https://github.com/firebase/FirebaseUI-Flutter/issues/212

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
