### PR TITLE
fix(ui_localizations): Add missing 'nb' language code to kSupportedLanguages

### DIFF
--- a/packages/firebase_ui_localizations/lib/src/get_localization.dart
+++ b/packages/firebase_ui_localizations/lib/src/get_localization.dart
@@ -21,6 +21,7 @@ final Set<String> kSupportedLanguages = {
   'ja', // Japanese
   'ko', // Korean
   'nl', // Dutch Flemish
+  'nb', // Norwegian Bokmål
   'pl', // Polish
   'pt', // Portuguese
   'ro', // Romanian


### PR DESCRIPTION
## Description

Locale('nb') wasn't working, so I had a look and noticed a missing string in the "kSupportedLanguages" list.
Forked, updated the package with the string, ran a dependency override to test and the error dissapeared 👍. 

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ x ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [ x ] I read and followed the [Flutter Style Guide].
- [ x ] I signed the [CLA].
- [ x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ x ] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
