### PR TITLE
fix(firebase_ui_auth): wrap email_link_sign_in_screen.dart with FirebaseUIActions

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/email_link_sign_in_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/email_link_sign_in_screen.dart
@@ -61,7 +61,9 @@ class EmailLinkSignInScreen extends ProviderScreen<EmailLinkAuthProvider> {
 
   @override
   Widget build(BuildContext context) {
-    return UniversalScaffold(
+    return FirebaseUIActions(
+      actions: actions ?? const [],
+      child: UniversalScaffold(
       body: ResponsivePage(
         breakpoint: breakpoint,
         headerBuilder: headerBuilder,
@@ -77,6 +79,7 @@ class EmailLinkSignInScreen extends ProviderScreen<EmailLinkAuthProvider> {
           ),
         ),
       ),
+    )
     );
   }
 }


### PR DESCRIPTION
Solution for bug #31

## Description

This PR addresses a bug in the `EmailLinkSignInScreen` by wrapping the `UniversalScaffold` widget with the `FirebaseUIActions` widget. The modification ensures that FirebaseUI actions are executed. Previously, the `UniversalScaffold` did not include Firebase UI actions, which led to actions not be executed

## Related Issues

Bugfix for [issue #31](https://github.com/firebase/FirebaseUI-Flutter/issues/31). This PR resolves the issue by ensuring that `FirebaseUIActions` are integrated, thus enabling proper handling of Firebase-related actions within the `EmailLinkSignInScreen`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

