### PR TITLE
chore: bump FlutterFire dependencies to latest & update deprecated members to latest

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -69,6 +69,16 @@ scripts:
       dirExists:
         - test
 
+  test:build:web:
+    run: |
+      melos exec -c 1 --fail-fast -- \
+        "cd example && flutter build web"
+    description: |
+      Build all example apps for web platform
+    packageFilters:
+      dirExists:
+        - example
+
   test:e2e:
     working-directory: tests
     run: flutter test integration_test/firebase_ui_test.dart -r github

--- a/packages/firebase_ui_auth/example/pubspec.yaml
+++ b/packages/firebase_ui_auth/example/pubspec.yaml
@@ -22,8 +22,8 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.6
-  firebase_auth: ^5.2.0
-  firebase_core: ^3.4.0
+  firebase_auth: ^5.2.1
+  firebase_core: ^3.4.1
   flutter:
     sdk: flutter
   flutter_localizations:

--- a/packages/firebase_ui_auth/example/pubspec.yaml
+++ b/packages/firebase_ui_auth/example/pubspec.yaml
@@ -22,8 +22,8 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.6
-  firebase_auth: ^5.0.0
-  firebase_core: ^3.0.0
+  firebase_auth: ^5.2.0
+  firebase_core: ^3.4.0
   flutter:
     sdk: flutter
   flutter_localizations:

--- a/packages/firebase_ui_auth/pubspec.yaml
+++ b/packages/firebase_ui_auth/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 
 dependencies:
   email_validator: ^2.1.17
-  firebase_auth: ^5.2.0
-  firebase_core: ^3.4.0
-  firebase_dynamic_links: ^6.0.5
+  firebase_auth: ^5.2.1
+  firebase_core: ^3.4.1
+  firebase_dynamic_links: ^6.0.6
   firebase_ui_localizations: ^1.12.0
   firebase_ui_oauth: ^1.5.3
   firebase_ui_shared: ^1.4.1

--- a/packages/firebase_ui_auth/pubspec.yaml
+++ b/packages/firebase_ui_auth/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 
 dependencies:
   email_validator: ^2.1.17
-  firebase_auth: ^5.0.0
-  firebase_core: ^3.0.0
-  firebase_dynamic_links: ^6.0.0
+  firebase_auth: ^5.2.0
+  firebase_core: ^3.4.0
+  firebase_dynamic_links: ^6.0.5
   firebase_ui_localizations: ^1.12.0
   firebase_ui_oauth: ^1.5.3
   firebase_ui_shared: ^1.4.1

--- a/packages/firebase_ui_database/example/pubspec.yaml
+++ b/packages/firebase_ui_database/example/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
-  firebase_core: ^3.0.0
-  firebase_database: ^11.0.0
+  firebase_core: ^3.4.0
+  firebase_database: ^11.1.1
 dev_dependencies:
   drive: ^1.0.0-1.0.nullsafety.5
   flutter_test:

--- a/packages/firebase_ui_database/example/pubspec.yaml
+++ b/packages/firebase_ui_database/example/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
-  firebase_core: ^3.4.0
-  firebase_database: ^11.1.1
+  firebase_core: ^3.4.1
+  firebase_database: ^11.1.2
 dev_dependencies:
   drive: ^1.0.0-1.0.nullsafety.5
   flutter_test:

--- a/packages/firebase_ui_database/lib/src/table_builder.dart
+++ b/packages/firebase_ui_database/lib/src/table_builder.dart
@@ -399,8 +399,7 @@ class _EditModalButtonBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = FirebaseUILocalizations.labelsOf(context);
 
-    return ButtonBar(
-      mainAxisSize: MainAxisSize.min,
+    return OverflowBar(
       alignment: MainAxisAlignment.end,
       children: [
         TextButton(

--- a/packages/firebase_ui_database/pubspec.yaml
+++ b/packages/firebase_ui_database/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  firebase_database: ^11.1.1
+  firebase_database: ^11.1.2
   firebase_ui_localizations: ^1.12.0
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_database/pubspec.yaml
+++ b/packages/firebase_ui_database/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  firebase_database: ^11.0.0
+  firebase_database: ^11.1.1
   firebase_ui_localizations: ^1.12.0
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_firestore/example/pubspec.yaml
+++ b/packages/firebase_ui_firestore/example/pubspec.yaml
@@ -30,9 +30,9 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_ui_firestore: ^1.6.4
-  cloud_firestore: ^5.0.0
+  cloud_firestore: ^5.4.0
   cupertino_icons: ^1.0.6
-  firebase_core: ^3.0.0
+  firebase_core: ^3.4.0
 dev_dependencies:
   drive: ^1.0.0-1.0.nullsafety.5
   flutter_test:

--- a/packages/firebase_ui_firestore/example/pubspec.yaml
+++ b/packages/firebase_ui_firestore/example/pubspec.yaml
@@ -30,9 +30,9 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_ui_firestore: ^1.6.4
-  cloud_firestore: ^5.4.0
+  cloud_firestore: ^5.4.1
   cupertino_icons: ^1.0.6
-  firebase_core: ^3.4.0
+  firebase_core: ^3.4.1
 dev_dependencies:
   drive: ^1.0.0-1.0.nullsafety.5
   flutter_test:

--- a/packages/firebase_ui_firestore/lib/src/table_builder.dart
+++ b/packages/firebase_ui_firestore/lib/src/table_builder.dart
@@ -521,8 +521,7 @@ class _EditModalButtonBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = FirebaseUILocalizations.labelsOf(context);
 
-    return ButtonBar(
-      mainAxisSize: MainAxisSize.min,
+    return OverflowBar(
       alignment: MainAxisAlignment.end,
       children: [
         TextButton(

--- a/packages/firebase_ui_firestore/pubspec.yaml
+++ b/packages/firebase_ui_firestore/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  cloud_firestore: ^5.4.0
+  cloud_firestore: ^5.4.1
   firebase_ui_localizations: ^1.12.0
   firebase_ui_shared: ^1.4.1
   flutter:

--- a/packages/firebase_ui_firestore/pubspec.yaml
+++ b/packages/firebase_ui_firestore/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  cloud_firestore: ^5.0.0
+  cloud_firestore: ^5.4.0
   firebase_ui_localizations: ^1.12.0
   firebase_ui_shared: ^1.4.1
   flutter:

--- a/packages/firebase_ui_localizations/example/pubspec.yaml
+++ b/packages/firebase_ui_localizations/example/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   cupertino_icons: ^1.0.6
 
-  firebase_core: ^3.4.0
+  firebase_core: ^3.4.1
   firebase_ui_auth: ^1.15.0
   firebase_ui_localizations: ^1.12.0
   flutter:

--- a/packages/firebase_ui_localizations/example/pubspec.yaml
+++ b/packages/firebase_ui_localizations/example/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   cupertino_icons: ^1.0.6
 
-  firebase_core: ^3.0.0
+  firebase_core: ^3.4.0
   firebase_ui_auth: ^1.15.0
   firebase_ui_localizations: ^1.12.0
   flutter:

--- a/packages/firebase_ui_oauth/example/pubspec.yaml
+++ b/packages/firebase_ui_oauth/example/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
-  firebase_auth: ^5.0.0
-  firebase_core: ^3.0.0
+  firebase_auth: ^5.2.0
+  firebase_core: ^3.4.0
   firebase_ui_oauth: ^1.5.3
   firebase_ui_oauth_apple: ^1.2.21
   firebase_ui_oauth_facebook: ^1.2.21

--- a/packages/firebase_ui_oauth/example/pubspec.yaml
+++ b/packages/firebase_ui_oauth/example/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
-  firebase_auth: ^5.2.0
-  firebase_core: ^3.4.0
+  firebase_auth: ^5.2.1
+  firebase_core: ^3.4.1
   firebase_ui_oauth: ^1.5.3
   firebase_ui_oauth_apple: ^1.2.21
   firebase_ui_oauth_facebook: ^1.2.21

--- a/packages/firebase_ui_oauth/pubspec.yaml
+++ b/packages/firebase_ui_oauth/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   desktop_webview_auth: ^0.0.14
-  firebase_auth: ^5.2.0
+  firebase_auth: ^5.2.1
   firebase_ui_auth: ^1.15.0
   firebase_ui_shared: ^1.4.1
   flutter_svg: ^2.0.9

--- a/packages/firebase_ui_oauth/pubspec.yaml
+++ b/packages/firebase_ui_oauth/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   desktop_webview_auth: ^0.0.14
-  firebase_auth: ^5.0.0
+  firebase_auth: ^5.2.0
   firebase_ui_auth: ^1.15.0
   firebase_ui_shared: ^1.4.1
   flutter_svg: ^2.0.9

--- a/packages/firebase_ui_oauth_apple/pubspec.yaml
+++ b/packages/firebase_ui_oauth_apple/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  firebase_auth: ^5.2.0
+  firebase_auth: ^5.2.1
   firebase_ui_oauth: ^1.5.3
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_oauth_apple/pubspec.yaml
+++ b/packages/firebase_ui_oauth_apple/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  firebase_auth: ^5.0.0
+  firebase_auth: ^5.2.0
   firebase_ui_oauth: ^1.5.3
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_oauth_facebook/pubspec.yaml
+++ b/packages/firebase_ui_oauth_facebook/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  firebase_auth: ^5.2.0
+  firebase_auth: ^5.2.1
   firebase_ui_oauth: ^1.5.3
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_oauth_facebook/pubspec.yaml
+++ b/packages/firebase_ui_oauth_facebook/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  firebase_auth: ^5.0.0
+  firebase_auth: ^5.2.0
   firebase_ui_oauth: ^1.5.3
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_oauth_google/pubspec.yaml
+++ b/packages/firebase_ui_oauth_google/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  firebase_auth: ^5.2.0
+  firebase_auth: ^5.2.1
   firebase_ui_oauth: ^1.5.3
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_oauth_google/pubspec.yaml
+++ b/packages/firebase_ui_oauth_google/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  firebase_auth: ^5.0.0
+  firebase_auth: ^5.2.0
   firebase_ui_oauth: ^1.5.3
   flutter:
     sdk: flutter

--- a/packages/firebase_ui_oauth_twitter/pubspec.yaml
+++ b/packages/firebase_ui_oauth_twitter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_auth: ^5.2.0
+  firebase_auth: ^5.2.1
   firebase_ui_oauth: ^1.5.3
   twitter_login: ^4.4.2
 

--- a/packages/firebase_ui_oauth_twitter/pubspec.yaml
+++ b/packages/firebase_ui_oauth_twitter/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_auth: ^5.0.0
+  firebase_auth: ^5.2.0
   firebase_ui_oauth: ^1.5.3
   twitter_login: ^4.4.2
 

--- a/packages/firebase_ui_storage/example/pubspec.yaml
+++ b/packages/firebase_ui_storage/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   cupertino_icons: ^1.0.6
   file_picker: ^6.1.1
-  firebase_core: ^3.0.0
-  firebase_storage: ^12.0.0
+  firebase_core: ^3.4.0
+  firebase_storage: ^12.2.0
   firebase_ui_storage: ^2.0.5
   firebase_ui_shared: ^1.4.1
 

--- a/packages/firebase_ui_storage/example/pubspec.yaml
+++ b/packages/firebase_ui_storage/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   cupertino_icons: ^1.0.6
   file_picker: ^6.1.1
-  firebase_core: ^3.4.0
-  firebase_storage: ^12.2.0
+  firebase_core: ^3.4.1
+  firebase_storage: ^12.3.0
   firebase_ui_storage: ^2.0.5
   firebase_ui_shared: ^1.4.1
 

--- a/packages/firebase_ui_storage/pubspec.yaml
+++ b/packages/firebase_ui_storage/pubspec.yaml
@@ -13,7 +13,7 @@ false_secrets:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_storage: ^12.2.0
+  firebase_storage: ^12.3.0
   firebase_ui_localizations: ^1.12.0
   firebase_ui_shared: ^1.4.1
   path: ^1.8.3

--- a/packages/firebase_ui_storage/pubspec.yaml
+++ b/packages/firebase_ui_storage/pubspec.yaml
@@ -13,7 +13,7 @@ false_secrets:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_storage: ^12.0.0
+  firebase_storage: ^12.2.0
   firebase_ui_localizations: ^1.12.0
   firebase_ui_shared: ^1.4.1
   path: ^1.8.3

--- a/scripts/update_dependencies.dart
+++ b/scripts/update_dependencies.dart
@@ -10,7 +10,7 @@ import 'package:yaml_edit/yaml_edit.dart';
 
 Future<void> main(List<String> args) async {
   const bomPath =
-      'https://raw.githubusercontent.com/firebase/flutterfire/master/scripts/versions.json';
+      'https://raw.githubusercontent.com/firebase/flutterfire/main/scripts/versions.json';
   final http = HttpClient();
   final request = await http.getUrl(Uri.parse(bomPath));
   final response = await request.close(); // sends the request

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -29,7 +29,7 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.27.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '11.0.0'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/tests/macos/Podfile
+++ b/tests/macos/Podfile
@@ -30,7 +30,7 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.27.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '11.0.0'
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/tests/pubspec.yaml
+++ b/tests/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.6
-  firebase_auth: ^5.2.0
-  firebase_core: ^3.4.0
+  firebase_auth: ^5.2.1
+  firebase_core: ^3.4.1
   firebase_ui_auth: ^1.15.0
   firebase_ui_localizations: ^1.12.0
   firebase_ui_oauth_apple: ^1.2.21
@@ -21,12 +21,12 @@ dependencies:
   flutter_facebook_auth: ^6.0.3
   twitter_login: ^4.4.2
   firebase_ui_oauth_twitter: ^1.2.21
-  cloud_firestore: ^5.4.0
+  cloud_firestore: ^5.4.1
   firebase_ui_firestore: ^1.6.4
   http: ^1.1.2
   google_sign_in: ^6.2.1
   firebase_ui_shared: ^1.4.1
-  firebase_database: ^11.1.1
+  firebase_database: ^11.1.2
   firebase_ui_database: ^1.4.4
 
 dev_dependencies:

--- a/tests/pubspec.yaml
+++ b/tests/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.6
-  firebase_auth: ^5.0.0
-  firebase_core: ^3.0.0
+  firebase_auth: ^5.2.0
+  firebase_core: ^3.4.0
   firebase_ui_auth: ^1.15.0
   firebase_ui_localizations: ^1.12.0
   firebase_ui_oauth_apple: ^1.2.21
@@ -21,12 +21,12 @@ dependencies:
   flutter_facebook_auth: ^6.0.3
   twitter_login: ^4.4.2
   firebase_ui_oauth_twitter: ^1.2.21
-  cloud_firestore: ^5.0.0
+  cloud_firestore: ^5.4.0
   firebase_ui_firestore: ^1.6.4
   http: ^1.1.2
   google_sign_in: ^6.2.1
   firebase_ui_shared: ^1.4.1
-  firebase_database: ^11.0.0
+  firebase_database: ^11.1.1
   firebase_ui_database: ^1.4.4
 
 dev_dependencies:


### PR DESCRIPTION
## Description

- Tested macOS, iOS and android e2e tests locally. CI is flakey for now and I'll be looking to find a way to test without being blocked by CI. 
- Built all examples in web to prove they build successfully.

## Related Issues

_Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/firebase/FirebaseUI-Flutter/issues). Indicate, which of these issues are resolved or fixed by this PR._

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
