### PR TITLE
feat: updated default loading indicator to be platform adaptive

### DIFF
--- a/packages/firebase_ui_database/lib/src/query_builder.dart
+++ b/packages/firebase_ui_database/lib/src/query_builder.dart
@@ -438,7 +438,7 @@ class FirebaseDatabaseListView extends FirebaseDatabaseQueryBuilder {
           builder: (context, snapshot, _) {
             if (snapshot.isFetching) {
               return loadingBuilder?.call(context) ??
-                  const Center(child: CircularProgressIndicator());
+                  const Center(child: CircularProgressIndicator.adaptive());
             }
 
             if (snapshot.hasError && errorBuilder != null) {

--- a/packages/firebase_ui_firestore/lib/src/query_builder.dart
+++ b/packages/firebase_ui_firestore/lib/src/query_builder.dart
@@ -460,7 +460,7 @@ class FirestoreListView<Document> extends FirestoreQueryBuilder<Document> {
           builder: (context, snapshot, _) {
             if (snapshot.isFetching) {
               return loadingBuilder?.call(context) ??
-                  const Center(child: CircularProgressIndicator());
+                  const Center(child: CircularProgressIndicator.adaptive());
             }
 
             if (snapshot.hasError && errorBuilder != null) {
@@ -570,7 +570,7 @@ class FirestoreListView<Document> extends FirestoreQueryBuilder<Document> {
           builder: (context, snapshot, _) {
             if (snapshot.isFetching) {
               return loadingBuilder?.call(context) ??
-                  const Center(child: CircularProgressIndicator());
+                  const Center(child: CircularProgressIndicator.adaptive());
             }
 
             if (snapshot.hasError && errorBuilder != null) {


### PR DESCRIPTION
## Description

Updates the default loading indicator for Pagination widgets like `FirebaseDatabaseListView` and `FirestoreListView` to be platform adaptive.

## Related Issues

fixes #398

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
