### PR TITLE
fix(ui localizations): fixed typos and added translations to 'pt' (Portugese)

### DIFF
--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pt.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pt.arb
@@ -61,7 +61,7 @@
     "description": "Used as a label of the DeleteAccountButton.",
     "placeholders": {}
   },
-  "differentMethodsSignInTitleText": "Uso um dos métodos a seguir para fazer login",
+  "differentMethodsSignInTitleText": "Use um dos métodos a seguir para fazer login",
   "@differentMethodsSignInTitleText": {
     "description": "Used as a title of the dialog that indicates that there are different available sign in methods for a provided email.",
     "placeholders": {}
@@ -76,12 +76,12 @@
     "description": "",
     "placeholders": {}
   },
-  "emailInputLabel": "E-mail",
+  "emailInputLabel": "Email",
   "@emailInputLabel": {
     "description": "Used as a label of the EmailInput.",
     "placeholders": {}
   },
-  "emailIsRequiredErrorText": "O e-mail é obrigatório",
+  "emailIsRequiredErrorText": "O email é obrigatório",
   "@emailIsRequiredErrorText": {
     "description": "Used as an error text of the EmailInput when the email is empty.",
     "placeholders": {}
@@ -91,7 +91,7 @@
     "description": "Used as a label of the EmailLinkSignInButton.",
     "placeholders": {}
   },
-  "emailTakenErrorText": "Já existe uma conta com este e-mail",
+  "emailTakenErrorText": "Já existe uma conta com este email",
   "@emailTakenErrorText": {
     "description": "Used as an error message when the user tries to sign up with an email that is already used.",
     "placeholders": {}
@@ -106,12 +106,12 @@
     "description": "Used as a hint to connect more providers.",
     "placeholders": {}
   },
-  "enterSMSCodeText": "Informar o código SMS",
+  "enterSMSCodeText": "Introduza o código SMS",
   "@enterSMSCodeText": {
     "description": "Used as a label of the SMSCodeInput.",
     "placeholders": {}
   },
-  "findProviderForEmailTitleText": "Insira seu e-mail para continuar",
+  "findProviderForEmailTitleText": "Insira seu email para continuar",
   "@findProviderForEmailTitleText": {
     "description": "Used as a title of the FindProvidersForEmailView.",
     "placeholders": {}
@@ -121,7 +121,7 @@
     "description": "Used as a label of the ForgotPasswordButton.",
     "placeholders": {}
   },
-  "forgotPasswordHintText": "Forneça seu e-mail. Depois disso, vamos enviar uma mensagem com um link para redefinir sua senha",
+  "forgotPasswordHintText": "Forneça seu email. Depois disso, vamos enviar uma mensagem com um link para redefinir sua senha",
   "@forgotPasswordHintText": {
     "description": "Used as a hint on a ForgotPasswordView.",
     "placeholders": {}
@@ -150,7 +150,7 @@
     "description": "Used as an error text when provide country code is invalid.",
     "placeholders": {}
   },
-  "isNotAValidEmailErrorText": "Forneça um e-mail válido",
+  "isNotAValidEmailErrorText": "Forneça um email válido",
   "@isNotAValidEmailErrorText": {
     "description": "Used as an error text of the EmailInput if the provided email is not valid.",
     "placeholders": {}
@@ -220,7 +220,7 @@
     "description": "Used as an error text when PasswordInput is empty.",
     "placeholders": {}
   },
-  "passwordResetEmailSentText": "Enviamos para seu e-mail um link que permite redefinir sua senha. Confira sua caixa de entrada.",
+  "passwordResetEmailSentText": "Enviámos para seu email um link que permite redefinir sua senha. Confira sua caixa de entrada.",
   "@passwordResetEmailSentText": {
     "description": "Indicates that the password reset email was sent.",
     "placeholders": {}
@@ -250,7 +250,7 @@
     "description": "A title of the ProfileScreen.",
     "placeholders": {}
   },
-  "provideEmail": "Forneça seu e-mail e senha",
+  "provideEmail": "Forneça seu email e senha",
   "@provideEmail": {
     "description": "Used as a title of the EmailSignUpDialog.",
     "placeholders": {}
@@ -314,7 +314,7 @@
     "description": "Used as a label of the OAuthProviderButton for Apple provider.",
     "placeholders": {}
   },
-  "signInWithEmailLinkSentText": "Enviamos um link mágico para seu e-mail. Confira sua caixa de entrada e clique nesse link para fazer login",
+  "signInWithEmailLinkSentText": "Enviámos um link mágico para seu email. Confira sua caixa de entrada e clique nesse link para fazer login",
   "@signInWithEmailLinkSentText": {
     "description": "Indicates that email with a sign in link was sent.",
     "placeholders": {}
@@ -424,47 +424,47 @@
     "description": "Used as an error text of the PasswordInput when provided password is empty or is not correct.",
     "placeholders": {}
   },
-  "uploadButtonText": "Upload file",
+  "uploadButtonText": "Carregue ficheiro",
   "@uploadButtonText": {
     "description": "UploadButton label",
     "placeholders": {}
   },
-  "verifyEmailTitle": "Verify your email",
+  "verifyEmailTitle": "Verifique o seu email",
   "@verifyEmailTitle": {
     "description": "EmailVerificationScreen title",
     "placeholders": {}
   },
-  "verificationEmailSentText": "A verification email has been sent to your email address. Please check your email and click on the link to verify your email address.",
+  "verificationEmailSentText": "Um email de verificação foi enviado para seu email. Confira sua caixa de entrada e clique no link para verificar o seu endereço de email.",  
   "@verificationEmailSentText": {
     "description": "Hint text indicating that verification email has been sent",
     "placeholders": {}
   },
-  "verificationFailedText": "We couldn't verify your email address. ",
+  "verificationFailedText": "Não conseguimos verificar seu endereço de email. ",
   "@verificationFailedText": {
     "description": "Message indicating that something went wrong during email verification",
     "placeholders": {}
   },
-  "resendVerificationEmailButtonLabel": "Resend verification email",
+  "resendVerificationEmailButtonLabel": "Reenviar email de verificação",
   "@resendVerificationEmailButtonLabel": {
     "description": "Button label that suggests to resend verification email",
     "placeholders": {}
   },
-  "verificationEmailSentTextShort": "Verification email sent",
+  "verificationEmailSentTextShort": "Email de verificação enviado",
   "@verificationEmailSentTextShort": {
     "description": "Short version of the hint text indicating that verification email has been sent",
     "placeholders": {}
   },
-  "emailIsNotVerifiedText": "Email is not verified",
+  "emailIsNotVerifiedText": "Email não está verificado",
   "@emailIsNotVerifiedText": {
     "description": "Message indicating that email is not verified",
     "placeholders": {}
   },
-  "waitingForEmailVerificationText": "Waiting for email verification",
+  "waitingForEmailVerificationText": "Aguardando verificação do email",
   "@waitingForEmailVerificationText": {
     "description": "Message indicating that email is being verified",
     "placeholders": {}
   },
-  "dismissButtonLabel": "Dismiss",
+  "dismissButtonLabel": "Ignorar",
   "@dismiss": {
     "description": "Dissmiss button label",
     "placeholders": {}
@@ -474,62 +474,62 @@
     "description": "OK button label",
     "placeholders": {}
   },
-  "checkEmailHintText": "Please check your email and click the link to verify your email address.",
+  "checkEmailHintText": "Por favor confira sua caixa de entrada e clique no link para verificar seu endereço de email.",
   "@checkEmailHintText": {
     "description": "Hint text prompting the user to check email for verification link",
     "placeholders": {}
   },
-  "doneButtonLabel": "Done",
+  "doneButtonLabel": "Feito",
   "@doneButtonLabel": {
     "description": "Done button label",
     "placeholders": {}
   },
-  "invalidVerificationCodeErrorText": "The code you entered is invalid. Please try again.",
+  "invalidVerificationCodeErrorText": "O código que inseriu é inválido. Por favor tente novamente.",
   "@invalidVerificationCodeErrorText": {
     "description": "Error text indicating that entered SMS code is invalid",
     "placeholders": {}
   },
-  "ulinkProviderAlertTitle": "Unlink provider",
+  "ulinkProviderAlertTitle": "Desassociar provedor",
   "@ulinkProviderAlertTitle": {
     "description": "Title that is shown in AlertDialog asking for provider unlink confirmation",
     "placeholders": {}
   },
-  "confirmUnlinkButtonLabel": "Unlink",
+  "confirmUnlinkButtonLabel": "Desassociar",
   "@confirmUnlinkButtonLabel": {
     "description": "Unlink confirmation button label",
     "placeholders": {}
   },
-  "cancelButtonLabel": "Cancel",
+  "cancelButtonLabel": "Cancelar",
   "@cancelButtonLabel": {
     "description": "Cancel button label",
     "placeholders": {}
   },
-  "unlinkProviderAlertMessage": "Are you sure you want to unlink this provider?",
+  "unlinkProviderAlertMessage": "Tem a certeza que quer desassociar este provedor?",
   "@unlinkProviderAlertMessage": {
     "description": "Text that is shown as a message of the AlertDialog confirming provider unlink",
     "placeholders": {}
   },
-  "weakPasswordErrorText": "Password should be at least 6 characters",
+  "weakPasswordErrorText": "A senha deve ter pelo menos 6 caracteres",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
     "placeholders": {}
   },
-  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "confirmDeleteAccountAlertTitle": "Confirmar eliminação de conta",
   "@confirmDeleteAccountAlertTitle": {
     "description": "Delete account confirmation dialog title",
     "placeholders": {}
   },
-  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "confirmDeleteAccountAlertMessage": Tem a certeza que quer eliminar sua conta?",
   "@confirmDeleteAccountAlertMessage": {
     "description": "Delete account confirmation dialog message",
     "placeholders": {}
   },
-  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "confirmDeleteAccountButtonLabel": "Sim, eliminar",
   "@confirmDeleteAccountButtonLabel": {
     "description": "Confirm delete account button label",
     "placeholders": {}
   },
-  "sendVerificationEmailLabel": "Send verification email",
+  "sendVerificationEmailLabel": "Enviar email de verificação",
   "@sendVerificationEmailLabel": {
     "description": "Used as a button label to send a verification email",
     "placeholders": {}


### PR DESCRIPTION
## Description

Some of the strings were not translated to 'pt' and were still in English. 

I also changed:
1. 'e-mail' to 'email', to be consistent with english
2. 'Uso um dos métodos' to 'Use um dos métodos' (typo)
3. 'Informar o código SMS' to 'Introduza o código SMS' (typo)
4. 'Enviamos um link' to 'Enviámos um link' (typo)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

