### PR TITLE
fix(auth): using theme color instead of hardcoded value

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -387,7 +387,7 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
         children: [
           Container(
             decoration: BoxDecoration(
-              color: Colors.yellow,
+              color: Theme.of(context).colorScheme.surface,
               borderRadius: BorderRadius.circular(12),
             ),
             child: Padding(


### PR DESCRIPTION
## Description

Instead of using a hardcoded color value, the Theme colors should be used. This is how the component looks right now with dark mode:
![SCR-20241015-jnoc](https://github.com/user-attachments/assets/ee3f477f-8d05-4037-a8f7-9c7498c03475)

As you can see it is not really readable. 


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]). (not needed?)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
