### PR TITLE
fix(auth): remove listener on dispose and only call setState when mounted

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -354,11 +354,27 @@ class _EmailVerificationBadge extends StatefulWidget {
 }
 
 class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
-  late final service = EmailVerificationController(widget.auth)
-    ..addListener(() {
-      setState(() {});
-    })
-    ..reload();
+  late final service;
+  late final VoidCallback listener;
+
+  @override
+  void initState() {
+    super.initState();
+    listener = () {
+      if (mounted) {
+        setState(() {});
+      }
+    };
+    service = EmailVerificationController(widget.auth)
+      ..addListener(listener)
+      ..reload();
+  }
+
+  @override
+  void dispose() {
+    service.removeListener(listener);
+    super.dispose();
+  }
 
   EmailVerificationState get state => service.state;
 

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -354,7 +354,7 @@ class _EmailVerificationBadge extends StatefulWidget {
 }
 
 class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
-  late final service;
+  late final EmailVerificationController service;
   late final VoidCallback listener;
 
   @override


### PR DESCRIPTION
## Description

_Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change._

## Related Issues

Fix confirmed here: https://github.com/firebase/FirebaseUI-Flutter/issues/353#issuecomment-2471823335

fixes https://github.com/firebase/FirebaseUI-Flutter/issues/353

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
