### PR TITLE
docs(firebase_ui_auth): Handle `UserCreated` event in `README` example

### DIFF
--- a/packages/firebase_ui_auth/README.md
+++ b/packages/firebase_ui_auth/README.md
@@ -44,6 +44,10 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final providers = [EmailAuthProvider()];
 
+    void onSignedIn() {
+      Navigator.pushReplacementNamed(context, '/profile');
+    }
+
     return MaterialApp(
       initialRoute: FirebaseAuth.instance.currentUser == null ? '/sign-in' : '/profile',
       routes: {
@@ -51,8 +55,12 @@ class MyApp extends StatelessWidget {
           return SignInScreen(
             providers: providers,
             actions: [
+              AuthStateChangeAction<UserCreated>((context, state) {
+                // Put any new user logic here
+                onSignedIn();
+              }),
               AuthStateChangeAction<SignedIn>((context, state) {
-                Navigator.pushReplacementNamed(context, '/profile');
+                onSignedIn();
               }),
             ],
           );


### PR DESCRIPTION
## Description

Demonstrate that the `UserCreated` event must be handled

## Related Issues

Fixes https://github.com/firebase/FirebaseUI-Flutter/issues/382

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
