### PR TITLE
fix(auth): fixed Google's icon background so it is transparent. For light and dark mode.

### DIFF
--- a/packages/firebase_ui_oauth/test/flutterfire_ui_oauth_test.dart
+++ b/packages/firebase_ui_oauth/test/flutterfire_ui_oauth_test.dart
@@ -30,7 +30,7 @@ const _iconSvg = '''
 <svg width="38px" height="38px" viewBox="0 0 38 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g id="Google-Button" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="btn_google_signin_dark_normal" transform="translate(-5.000000, -5.000000)">
-            <rect id="button-bg-copy" fill="#FFFFFF" x="5" y="5" width="38" height="38" rx="1"></rect>
+            <rect id="button-bg-copy" x="5" y="5" width="38" height="38" rx="1"></rect>
             <g id="logo_googleg_48dp" transform="translate(15.000000, 15.000000)">
                 <path d="M17.64,9.20454545 C17.64,8.56636364 17.5827273,7.95272727 17.4763636,7.36363636 L9,7.36363636 L9,10.845 L13.8436364,10.845 C13.635,11.97 13.0009091,12.9231818 12.0477273,13.5613636 L12.0477273,15.8195455 L14.9563636,15.8195455 C16.6581818,14.2527273 17.64,11.9454545 17.64,9.20454545 L17.64,9.20454545 Z" id="Shape" fill="#4285F4"></path>
                 <path d="M9,18 C11.43,18 13.4672727,17.1940909 14.9563636,15.8195455 L12.0477273,13.5613636 C11.2418182,14.1013636 10.2109091,14.4204545 9,14.4204545 C6.65590909,14.4204545 4.67181818,12.8372727 3.96409091,10.71 L0.957272727,10.71 L0.957272727,13.0418182 C2.43818182,15.9831818 5.48181818,18 9,18 L9,18 Z" id="Shape" fill="#34A853"></path>

--- a/packages/firebase_ui_oauth_google/assets/google_icon.svg
+++ b/packages/firebase_ui_oauth_google/assets/google_icon.svg
@@ -2,7 +2,7 @@
 <svg width="38px" height="38px" viewBox="0 0 38 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g id="Google-Button" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="btn_google_signin_dark_normal" transform="translate(-5.000000, -5.000000)">
-            <rect id="button-bg-copy" fill="#FFFFFF" x="5" y="5" width="38" height="38" rx="1"></rect>
+            <rect id="button-bg-copy" x="5" y="5" width="38" height="38" rx="1"></rect>
             <g id="logo_googleg_48dp" transform="translate(15.000000, 15.000000)">
                 <path d="M17.64,9.20454545 C17.64,8.56636364 17.5827273,7.95272727 17.4763636,7.36363636 L9,7.36363636 L9,10.845 L13.8436364,10.845 C13.635,11.97 13.0009091,12.9231818 12.0477273,13.5613636 L12.0477273,15.8195455 L14.9563636,15.8195455 C16.6581818,14.2527273 17.64,11.9454545 17.64,9.20454545 L17.64,9.20454545 Z" id="Shape" fill="#4285F4"></path>
                 <path d="M9,18 C11.43,18 13.4672727,17.1940909 14.9563636,15.8195455 L12.0477273,13.5613636 C11.2418182,14.1013636 10.2109091,14.4204545 9,14.4204545 C6.65590909,14.4204545 4.67181818,12.8372727 3.96409091,10.71 L0.957272727,10.71 L0.957272727,13.0418182 C2.43818182,15.9831818 5.48181818,18 9,18 L9,18 Z" id="Shape" fill="#34A853"></path>

--- a/packages/firebase_ui_oauth_google/lib/src/theme.dart
+++ b/packages/firebase_ui_oauth_google/lib/src/theme.dart
@@ -17,7 +17,7 @@ const _iconSvg = '''
 <svg width="38px" height="38px" viewBox="0 0 38 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g id="Google-Button" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="btn_google_signin_dark_normal" transform="translate(-5.000000, -5.000000)">
-            <rect id="button-bg-copy" fill="#FFFFFF" x="5" y="5" width="38" height="38" rx="1"></rect>
+            <rect id="button-bg-copy" x="5" y="5" width="38" height="38" rx="1"></rect>
             <g id="logo_googleg_48dp" transform="translate(15.000000, 15.000000)">
                 <path d="M17.64,9.20454545 C17.64,8.56636364 17.5827273,7.95272727 17.4763636,7.36363636 L9,7.36363636 L9,10.845 L13.8436364,10.845 C13.635,11.97 13.0009091,12.9231818 12.0477273,13.5613636 L12.0477273,15.8195455 L14.9563636,15.8195455 C16.6581818,14.2527273 17.64,11.9454545 17.64,9.20454545 L17.64,9.20454545 Z" id="Shape" fill="#4285F4"></path>
                 <path d="M9,18 C11.43,18 13.4672727,17.1940909 14.9563636,15.8195455 L12.0477273,13.5613636 C11.2418182,14.1013636 10.2109091,14.4204545 9,14.4204545 C6.65590909,14.4204545 4.67181818,12.8372727 3.96409091,10.71 L0.957272727,10.71 L0.957272727,13.0418182 C2.43818182,15.9831818 5.48181818,18 9,18 L9,18 Z" id="Shape" fill="#34A853"></path>


### PR DESCRIPTION
## Description

Removed google_icon.svg white background, so that GoogleSignInButton looks correct in light and dark mode.

I have not spent enough time with the repo to be sure of this, however I believe that directory `firebase_ui_oath_google/assets` and `google_icon.svg` can be deleted altogether, because they are not being used. Correct my if I am wrong.

## Related Issues

fixes https://github.com/firebase/FirebaseUI-Flutter/issues/16

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
