### PR TITLE
feat(firebase_ui_auth): Use icon from OAuth provider as a fallback in ProfileScreen

### DIFF
--- a/packages/firebase_ui_auth/lib/src/oauth/provider_resolvers.dart
+++ b/packages/firebase_ui_auth/lib/src/oauth/provider_resolvers.dart
@@ -4,8 +4,11 @@
 
 // ignore_for_file: constant_identifier_names
 
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 
 import 'social_icons.dart';
 
@@ -22,31 +25,55 @@ const PASSWORD_PROVIDER_ID = 'password';
 /// final icon = providerIcon(context, 'google.com');
 /// Icon(icon);
 /// ```
-IconData providerIcon(BuildContext context, String providerId) {
+Widget providerIcon(BuildContext context, AuthProvider provider) {
+  final providerId = provider.providerId;
   final isCupertino = CupertinoUserInterfaceLevel.maybeOf(context) != null;
 
+  final IconData? data;
   switch (providerId) {
     case GOOGLE_PROVIDER_ID:
-      return SocialIcons.google;
+      data = SocialIcons.google;
+      break;
     case APPLE_PROVIDER_ID:
-      return SocialIcons.apple;
+      data = SocialIcons.apple;
+      break;
     case TWITTER_PROVIDER_ID:
-      return SocialIcons.twitter;
+      data = SocialIcons.twitter;
+      break;
     case FACEBOOK_PROVIDER_ID:
-      return SocialIcons.facebook;
+      data = SocialIcons.facebook;
+      break;
     case PHONE_PROVIDER_ID:
       if (isCupertino) {
-        return CupertinoIcons.phone;
+        data = CupertinoIcons.phone;
       } else {
-        return Icons.phone;
+        data = Icons.phone;
       }
+      break;
     case PASSWORD_PROVIDER_ID:
       if (isCupertino) {
-        return CupertinoIcons.mail;
+        data = CupertinoIcons.mail;
       } else {
-        return Icons.email_outlined;
+        data = Icons.email_outlined;
       }
+      break;
     default:
-      throw Exception('Unknown provider: $providerId');
+      data = null;
   }
+
+  if (data != null) {
+    return Icon(data);
+  }
+
+  if (provider is OAuthProvider) {
+    final deviceBrightness =
+        CupertinoTheme.of(context).brightness ?? Theme.of(context).brightness;
+    final iconBrightness = deviceBrightness == Brightness.light
+        ? Brightness.dark
+        : Brightness.light;
+    final style = provider.style.withBrightness(iconBrightness);
+    return SvgPicture.string(style.iconSrc);
+  }
+
+  throw Exception('Unknown provider: $providerId');
 }

--- a/packages/firebase_ui_auth/lib/src/oauth/provider_resolvers.dart
+++ b/packages/firebase_ui_auth/lib/src/oauth/provider_resolvers.dart
@@ -10,8 +10,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
-import 'social_icons.dart';
-
 const GOOGLE_PROVIDER_ID = 'google.com';
 const APPLE_PROVIDER_ID = 'apple.com';
 const TWITTER_PROVIDER_ID = 'twitter.com';

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -89,15 +89,11 @@ class _AvailableProvidersRowState extends State<_AvailableProvidersRow> {
                   context: context,
                   provider: provider,
                 ).then((_) => widget.onProviderLinked()),
-                child: Icon(
-                  providerIcon(context, provider.providerId),
-                ),
+                child: providerIcon(context, provider),
               )
             else
               IconButton(
-                icon: Icon(
-                  providerIcon(context, provider.providerId),
-                ),
+                icon: providerIcon(context, provider),
                 onPressed: () => connectProvider(
                   context: context,
                   provider: provider,
@@ -246,7 +242,8 @@ class _LinkedProvidersRowState extends State<_LinkedProvidersRow> {
     }
   }
 
-  Widget buildProviderIcon(BuildContext context, String providerId) {
+  Widget buildProviderIcon(BuildContext context, AuthProvider provider) {
+    final providerId = provider.providerId;
     final isCupertino = CupertinoUserInterfaceLevel.maybeOf(context) != null;
     const animationDuration = Duration(milliseconds: 150);
     const curve = Curves.easeOut;
@@ -267,7 +264,7 @@ class _LinkedProvidersRowState extends State<_LinkedProvidersRow> {
                   size: size - (size / 4),
                   borderWidth: 1,
                 )
-              : Icon(providerIcon(context, providerId)),
+              : providerIcon(context, provider),
         ),
         if (unlinkingProvider != providerId)
           AnimatedOpacity(
@@ -306,7 +303,7 @@ class _LinkedProvidersRowState extends State<_LinkedProvidersRow> {
     Widget child = Row(
       children: [
         for (var provider in widget.providers)
-          buildProviderIcon(context, provider.providerId)
+          buildProviderIcon(context, provider)
       ]
           .map((e) => [e, const SizedBox(width: 8)])
           .expand((element) => element)

--- a/packages/firebase_ui_auth/pubspec.yaml
+++ b/packages/firebase_ui_auth/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  flutter_svg: ^2.0.16
   meta: ^1.10.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description

In the `ProfileScreen`, use the OAuth provider icon as a fallback if available

## Related Issues

https://github.com/firebase/FirebaseUI-Flutter/issues/383

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
