### PR TITLE
fix(ui_auth): Dispose controller after email verification

### DIFF
--- a/packages/firebase_ui_auth/lib/src/email_verification.dart
+++ b/packages/firebase_ui_auth/lib/src/email_verification.dart
@@ -58,6 +58,12 @@ class EmailVerificationController extends ValueNotifier<EmailVerificationState>
   }
 
   @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       reload();

--- a/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
@@ -145,6 +145,12 @@ class __EmailVerificationScreenContentState
     super.initState();
   }
 
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
   void _sendEmailVerification(_) {
     controller
       ..addListener(() {


### PR DESCRIPTION
## Description

Before this change, EmailVerificationController created during email verification workflow remained active on the background. When user signed out within the same session, FurebaseAuth.currentUser become null and the controller accessed it assuming it's never null.

After the change, controller is disposed after leaving the verification screen.

## Related Issues

Fixes #9 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
