### PR TITLE
fix(ui_auth): Don't send verification email to verified address

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
@@ -146,19 +146,21 @@ class __EmailVerificationScreenContentState
   }
 
   void _sendEmailVerification(_) {
-    controller
-      ..addListener(() {
-        setState(() {});
+    controller.addListener(() {
+      setState(() {});
 
-        if (state == EmailVerificationState.verified) {
-          final action = FirebaseUIAction.ofType<EmailVerifiedAction>(context);
-          action?.callback();
-        }
-      })
-      ..sendVerificationEmail(
+      if (state == EmailVerificationState.verified) {
+        final action = FirebaseUIAction.ofType<EmailVerifiedAction>(context);
+        action?.callback();
+      }
+    });
+
+    if (state != EmailVerificationState.verified) {
+      controller.sendVerificationEmail(
         Theme.of(context).platform,
         widget.actionCodeSettings,
       );
+    }
   }
 
   EmailVerificationState get state => controller.state;


### PR DESCRIPTION
## Description

EmailVerificationScreen might be created a second time to perform an animated transition to another screen.

The second instance shouldn't send a verification email to an already verified address.

## Related Issues

_Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/firebase/FirebaseUI-Flutter/issues). Indicate, which of these issues are resolved or fixed by this PR._

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
