### PR TITLE
fix(firebase_ui_auth): Catch sms code validation

### DIFF
--- a/packages/firebase_ui_auth/lib/src/mfa.dart
+++ b/packages/firebase_ui_auth/lib/src/mfa.dart
@@ -48,11 +48,6 @@ Future<fba.UserCredential?> startPhoneMFAVerification({
   final hint = resolver.hints.first;
   var completer = Completer<fba.UserCredential?>();
 
-  completer.future.catchError((e) {
-    onError?.call(e as FirebaseException);
-    return null;
-  });
-
   final navigator = Navigator.of(context);
 
   final provider = PhoneAuthProvider();
@@ -66,12 +61,23 @@ Future<fba.UserCredential?> startPhoneMFAVerification({
 
   provider.authListener = flow;
 
+  completer.future.catchError((e) {
+    onError?.call(e as FirebaseException);
+    flow.onError(e);
+    return null;
+  });
+
   final flowKey = Object();
 
   final actions = [
     AuthStateChangeAction<CredentialReceived>((context, inner) {
       if (completer.isCompleted) {
         completer = Completer<fba.UserCredential>();
+        completer.future.catchError((e) {
+          onError?.call(e as FirebaseException);
+          flow.onError(e);
+          return null;
+        });
       }
 
       final cred = inner.credential as fba.PhoneAuthCredential;


### PR DESCRIPTION
## Description
This allow the user to pass an onError function when an error happen when validating the sms code

## Related Issues
https://github.com/firebase/FirebaseUI-Flutter/issues/481

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
