### PR TITLE
fix(firebase_ui_auth): Avoid redundant confirmation on account deletion

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
@@ -85,10 +85,10 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
   void Function() pop<T>(BuildContext context, T result) =>
       () => Navigator.of(context).pop(result);
 
-  Future<void> _deleteAccount() async {
+  Future<void> _deleteAccount({bool skipConfirmation = false}) async {
     bool? confirmed = !widget.showDeleteConfirmationDialog;
 
-    if (!confirmed) {
+    if (!confirmed && !skipConfirmation) {
       final l = FirebaseUILocalizations.labelsOf(context);
 
       confirmed = await showCupertinoDialog<bool?>(
@@ -116,17 +116,16 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
       final user = auth.currentUser!;
       await auth.currentUser?.delete();
 
-      FirebaseUIAction.ofType<AccountDeletedAction>(context)?.callback(
+      FirebaseUIAction.ofType<AccountDeletedAction>(
         context,
-        user,
-      );
+      )?.callback(context, user);
       await FirebaseUIAuth.signOut(context: context, auth: auth);
     } on fba.FirebaseAuthException catch (err) {
       if (err.code == 'requires-recent-login') {
         if (widget.onSignInRequired != null) {
           final signedIn = await widget.onSignInRequired!();
           if (signedIn) {
-            await _deleteAccount();
+            await _deleteAccount(skipConfirmation: true);
           }
         }
       }


### PR DESCRIPTION
## Description

When user try to delete his account, when the exception 'requires-recent-login' appear, user need to login again and click again on the modal to confirm the account deletion. That's redundant.

## Related Issues

This PR can also bring some beneficts to this PR : https://github.com/firebase/FirebaseUI-Flutter/pull/493, if developer override the deletion modal to provide one (for example) using a TextController to ensure that user well want to delete his account (no miss click), the recall of the confirmation will present twice a TextController to fill.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
