### PR TITLE
fix(firebase_ui_localizations): Expose const explicitly

### DIFF
--- a/packages/firebase_ui_localizations/lib/src/l10n.dart
+++ b/packages/firebase_ui_localizations/lib/src/l10n.dart
@@ -47,8 +47,8 @@ class FirebaseUILocalizations<T extends FirebaseUILocalizationLabels> {
 
   /// Localization delegate that could be provided to the
   /// [MaterialApp.localizationsDelegates].
-  static FirebaseUILocalizationDelegate delegate =
-      const FirebaseUILocalizationDelegate();
+  static const FirebaseUILocalizationDelegate delegate =
+      FirebaseUILocalizationDelegate();
 
   /// Should be used to override labels provided by the library.
   ///


### PR DESCRIPTION
Make the static const

## Description

The const keyword must be moved to let the static be const.

## Related Issues

I want to use the static as a const.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
