### PR TITLE
feat: Add missing translation values for French and update some Portugese

### DIFF
--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_fr.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_fr.arb
@@ -424,47 +424,47 @@
     "description": "Used as an error text of the PasswordInput when provided password is empty or is not correct.",
     "placeholders": {}
   },
-  "uploadButtonText": "Upload file",
+  "uploadButtonText": "Télécharger le fichier",
   "@uploadButtonText": {
     "description": "UploadButton label",
     "placeholders": {}
   },
-  "verifyEmailTitle": "Verify your email",
+  "verifyEmailTitle": "Vérifiez votre email",
   "@verifyEmailTitle": {
     "description": "EmailVerificationScreen title",
     "placeholders": {}
   },
-  "verificationEmailSentText": "A verification email has been sent to your email address. Please check your email and click on the link to verify your email address.",
+  "verificationEmailSentText": "Un e-mail de vérification a été envoyé à votre adresse e-mail. Veuillez vérifier votre adresse e-mail et cliquer sur le lien pour la vérifier.",
   "@verificationEmailSentText": {
     "description": "Hint text indicating that verification email has been sent",
     "placeholders": {}
   },
-  "verificationFailedText": "We couldn't verify your email address. ",
+  "verificationFailedText": "Nous n'avons pas pu vérifier votre adresse e-mail. ",
   "@verificationFailedText": {
     "description": "Message indicating that something went wrong during email verification",
     "placeholders": {}
   },
-  "resendVerificationEmailButtonLabel": "Resend verification email",
+  "resendVerificationEmailButtonLabel": "Renvoyer l'e-mail de vérification",
   "@resendVerificationEmailButtonLabel": {
     "description": "Button label that suggests to resend verification email",
     "placeholders": {}
   },
-  "verificationEmailSentTextShort": "Verification email sent",
+  "verificationEmailSentTextShort": "E-mail de vérification envoyé",
   "@verificationEmailSentTextShort": {
     "description": "Short version of the hint text indicating that verification email has been sent",
     "placeholders": {}
   },
-  "emailIsNotVerifiedText": "Email is not verified",
+  "emailIsNotVerifiedText": "L'e-mail n'est pas vérifié",
   "@emailIsNotVerifiedText": {
     "description": "Message indicating that email is not verified",
     "placeholders": {}
   },
-  "waitingForEmailVerificationText": "Waiting for email verification",
+  "waitingForEmailVerificationText": "En attente de vérification de l'e-mail",
   "@waitingForEmailVerificationText": {
     "description": "Message indicating that email is being verified",
     "placeholders": {}
   },
-  "dismissButtonLabel": "Dismiss",
+  "dismissButtonLabel": "Annuler",
   "@dismiss": {
     "description": "Dissmiss button label",
     "placeholders": {}
@@ -474,62 +474,62 @@
     "description": "OK button label",
     "placeholders": {}
   },
-  "checkEmailHintText": "Please check your email and click the link to verify your email address.",
+  "checkEmailHintText": "Veuillez vérifier votre e-mail et cliquer sur le lien pour vérifier votre adresse e-mail.",
   "@checkEmailHintText": {
     "description": "Hint text prompting the user to check email for verification link",
     "placeholders": {}
   },
-  "doneButtonLabel": "Done",
+  "doneButtonLabel": "Fait",
   "@doneButtonLabel": {
     "description": "Done button label",
     "placeholders": {}
   },
-  "invalidVerificationCodeErrorText": "The code you entered is invalid. Please try again.",
+  "invalidVerificationCodeErrorText": "Le code saisi est invalide. Veuillez réessayer.",
   "@invalidVerificationCodeErrorText": {
     "description": "Error text indicating that entered SMS code is invalid",
     "placeholders": {}
   },
-  "ulinkProviderAlertTitle": "Unlink provider",
+  "ulinkProviderAlertTitle": "Dissocier le fournisseur",
   "@ulinkProviderAlertTitle": {
     "description": "Title that is shown in AlertDialog asking for provider unlink confirmation",
     "placeholders": {}
   },
-  "confirmUnlinkButtonLabel": "Unlink",
+  "confirmUnlinkButtonLabel": "Dissocier",
   "@confirmUnlinkButtonLabel": {
     "description": "Unlink confirmation button label",
     "placeholders": {}
   },
-  "cancelButtonLabel": "Cancel",
+  "cancelButtonLabel": "Annuler",
   "@cancelButtonLabel": {
     "description": "Cancel button label",
     "placeholders": {}
   },
-  "unlinkProviderAlertMessage": "Are you sure you want to unlink this provider?",
+  "unlinkProviderAlertMessage": "Êtes-vous sûr de vouloir dissocier ce fournisseur ?",
   "@unlinkProviderAlertMessage": {
     "description": "Text that is shown as a message of the AlertDialog confirming provider unlink",
     "placeholders": {}
   },
-  "weakPasswordErrorText": "Password should be at least 6 characters",
+  "weakPasswordErrorText": "Le mot de passe doit comporter au moins 6 caractères",
   "@weakPasswordErrorText": {
     "description": "Error text suggesting that used password is too weak",
     "placeholders": {}
   },
-  "confirmDeleteAccountAlertTitle": "Confirm account deletion",
+  "confirmDeleteAccountAlertTitle": "Confirmer la suppression du compte",
   "@confirmDeleteAccountAlertTitle": {
     "description": "Delete account confirmation dialog title",
     "placeholders": {}
   },
-  "confirmDeleteAccountAlertMessage": "Are you sure you want to delete your account?",
+  "confirmDeleteAccountAlertMessage": "Êtes-vous sûr de vouloir supprimer votre compte ?",
   "@confirmDeleteAccountAlertMessage": {
     "description": "Delete account confirmation dialog message",
     "placeholders": {}
   },
-  "confirmDeleteAccountButtonLabel": "Yes, delete",
+  "confirmDeleteAccountButtonLabel": "Oui, supprimer",
   "@confirmDeleteAccountButtonLabel": {
     "description": "Confirm delete account button label",
     "placeholders": {}
   },
-  "sendVerificationEmailLabel": "Send verification email",
+  "sendVerificationEmailLabel": "Envoyer un e-mail de vérification",
   "@sendVerificationEmailLabel": {
     "description": "Used as a button label to send a verification email",
     "placeholders": {}

--- a/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pt.arb
+++ b/packages/firebase_ui_localizations/lib/l10n/firebase_ui_pt.arb
@@ -519,7 +519,7 @@
     "description": "Delete account confirmation dialog title",
     "placeholders": {}
   },
-  "confirmDeleteAccountAlertMessage": Tem a certeza que quer eliminar sua conta?",
+  "confirmDeleteAccountAlertMessage": "Tem a certeza que quer eliminar sua conta?",
   "@confirmDeleteAccountAlertMessage": {
     "description": "Delete account confirmation dialog message",
     "placeholders": {}

--- a/packages/firebase_ui_localizations/lib/src/default_localizations.dart
+++ b/packages/firebase_ui_localizations/lib/src/default_localizations.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/firebase_ui_localizations/lib/src/lang/ar.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ar.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/de.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/de.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/en.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/en.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/es.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/es.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/es_419.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/es_419.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/fi.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/fi.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/fr.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/fr.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';
@@ -274,76 +274,78 @@ class FrLocalizations extends FirebaseUILocalizationLabels {
       "Le mot de passe n'est pas valide ou l'utilisateur n'en possède pas";
 
   @override
-  String get uploadButtonText => "Upload file";
+  String get uploadButtonText => "Télécharger le fichier";
 
   @override
-  String get verifyEmailTitle => "Verify your email";
+  String get verifyEmailTitle => "Vérifiez votre email";
 
   @override
   String get verificationEmailSentText =>
-      "A verification email has been sent to your email address. Please check your email and click on the link to verify your email address.";
+      "Un e-mail de vérification a été envoyé à votre adresse e-mail. Veuillez vérifier votre adresse e-mail et cliquer sur le lien pour la vérifier.";
 
   @override
   String get verificationFailedText =>
-      "We couldn't verify your email address. ";
+      "Nous n'avons pas pu vérifier votre adresse e-mail. ";
 
   @override
-  String get resendVerificationEmailButtonLabel => "Resend verification email";
+  String get resendVerificationEmailButtonLabel =>
+      "Renvoyer l'e-mail de vérification";
 
   @override
-  String get verificationEmailSentTextShort => "Verification email sent";
+  String get verificationEmailSentTextShort => "E-mail de vérification envoyé";
 
   @override
-  String get emailIsNotVerifiedText => "Email is not verified";
+  String get emailIsNotVerifiedText => "L'e-mail n'est pas vérifié";
 
   @override
   String get waitingForEmailVerificationText =>
-      "Waiting for email verification";
+      "En attente de vérification de l'e-mail";
 
   @override
-  String get dismissButtonLabel => "Dismiss";
+  String get dismissButtonLabel => "Annuler";
 
   @override
   String get okButtonLabel => "OK";
 
   @override
   String get checkEmailHintText =>
-      "Please check your email and click the link to verify your email address.";
+      "Veuillez vérifier votre e-mail et cliquer sur le lien pour vérifier votre adresse e-mail.";
 
   @override
-  String get doneButtonLabel => "Done";
+  String get doneButtonLabel => "Fait";
 
   @override
   String get invalidVerificationCodeErrorText =>
-      "The code you entered is invalid. Please try again.";
+      "Le code saisi est invalide. Veuillez réessayer.";
 
   @override
-  String get ulinkProviderAlertTitle => "Unlink provider";
+  String get ulinkProviderAlertTitle => "Dissocier le fournisseur";
 
   @override
-  String get confirmUnlinkButtonLabel => "Unlink";
+  String get confirmUnlinkButtonLabel => "Dissocier";
 
   @override
-  String get cancelButtonLabel => "Cancel";
+  String get cancelButtonLabel => "Annuler";
 
   @override
   String get unlinkProviderAlertMessage =>
-      "Are you sure you want to unlink this provider?";
+      "Êtes-vous sûr de vouloir dissocier ce fournisseur ?";
 
   @override
   String get weakPasswordErrorText =>
-      "Password should be at least 6 characters";
+      "Le mot de passe doit comporter au moins 6 caractères";
 
   @override
-  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+  String get confirmDeleteAccountAlertTitle =>
+      "Confirmer la suppression du compte";
 
   @override
   String get confirmDeleteAccountAlertMessage =>
-      "Are you sure you want to delete your account?";
+      "Êtes-vous sûr de vouloir supprimer votre compte ?";
 
   @override
-  String get confirmDeleteAccountButtonLabel => "Yes, delete";
+  String get confirmDeleteAccountButtonLabel => "Oui, supprimer";
 
   @override
-  String get sendVerificationEmailLabel => "Send verification email";
+  String get sendVerificationEmailLabel => "Envoyer un e-mail de vérification";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/he.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/he.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/hi.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/hi.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/hu.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/hu.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/id.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/id.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/it.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/it.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/ja.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ja.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';
@@ -71,7 +71,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
   String get enableMoreSignInMethods => "その他のサインイン方法を有効にします";
 
   @override
-  String get enterSMSCodeText => "SMSコードを入力";
+  String get enterSMSCodeText => "SMS コードを入力";
 
   @override
   String get findProviderForEmailTitleText => "メールアドレスを入力して続行";
@@ -216,7 +216,7 @@ class JaLocalizations extends FirebaseUILocalizationLabels {
 
   @override
   String get smsAutoresolutionFailedError =>
-      "SMS コードを自動で解決できませんでした。コードを手動で入力してください";
+      "SMSコードを自動で解決できませんでした。コードを手動で入力してください";
 
   @override
   String get southInitialLabel => "S";

--- a/packages/firebase_ui_localizations/lib/src/lang/ko.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ko.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/nb.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/nb.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/nl.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/nl.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/pl.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/pl.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/pt.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/pt.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';
@@ -47,7 +47,7 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
 
   @override
   String get differentMethodsSignInTitleText =>
-      "Uso um dos métodos a seguir para fazer login";
+      "Use um dos métodos a seguir para fazer login";
 
   @override
   String get disable => "Desativar";
@@ -56,16 +56,16 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
   String get eastInitialLabel => "E";
 
   @override
-  String get emailInputLabel => "E-mail";
+  String get emailInputLabel => "Email";
 
   @override
-  String get emailIsRequiredErrorText => "O e-mail é obrigatório";
+  String get emailIsRequiredErrorText => "O email é obrigatório";
 
   @override
   String get emailLinkSignInButtonLabel => "Fazer login com um link mágico";
 
   @override
-  String get emailTakenErrorText => "Já existe uma conta com este e-mail";
+  String get emailTakenErrorText => "Já existe uma conta com este email";
 
   @override
   String get enable => "Ativar";
@@ -74,18 +74,17 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
   String get enableMoreSignInMethods => "Ative mais métodos de login";
 
   @override
-  String get enterSMSCodeText => "Informar o código SMS";
+  String get enterSMSCodeText => "Introduza o código SMS";
 
   @override
-  String get findProviderForEmailTitleText =>
-      "Insira seu e-mail para continuar";
+  String get findProviderForEmailTitleText => "Insira seu email para continuar";
 
   @override
   String get forgotPasswordButtonLabel => "Esqueceu a senha?";
 
   @override
   String get forgotPasswordHintText =>
-      "Forneça seu e-mail. Depois disso, vamos enviar uma mensagem com um link para redefinir sua senha";
+      "Forneça seu email. Depois disso, vamos enviar uma mensagem com um link para redefinir sua senha";
 
   @override
   String get forgotPasswordViewTitle => "Esqueci a senha";
@@ -100,7 +99,7 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
   String get invalidCountryCode => "Código inválido";
 
   @override
-  String get isNotAValidEmailErrorText => "Forneça um e-mail válido";
+  String get isNotAValidEmailErrorText => "Forneça um email válido";
 
   @override
   String get latitudeLabel => "latitude";
@@ -143,7 +142,7 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
 
   @override
   String get passwordResetEmailSentText =>
-      "Enviamos para seu e-mail um link que permite redefinir sua senha. Confira sua caixa de entrada.";
+      "Enviámos para seu email um link que permite redefinir sua senha. Confira sua caixa de entrada.";
 
   @override
   String get phoneInputLabel => "Número de telefone";
@@ -162,7 +161,7 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
   String get profile => "Perfil";
 
   @override
-  String get provideEmail => "Forneça seu e-mail e senha";
+  String get provideEmail => "Forneça seu email e senha";
 
   @override
   String get referenceLabel => "referência";
@@ -199,7 +198,7 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
 
   @override
   String get signInWithEmailLinkSentText =>
-      "Enviamos um link mágico para seu e-mail. Confira sua caixa de entrada e clique nesse link para fazer login";
+      "Enviámos um link mágico para seu email. Confira sua caixa de entrada e clique nesse link para fazer login";
 
   @override
   String get signInWithEmailLinkViewTitleText =>
@@ -268,76 +267,77 @@ class PtLocalizations extends FirebaseUILocalizationLabels {
       "A senha é inválida ou o usuário não tem uma senha";
 
   @override
-  String get uploadButtonText => "Upload file";
+  String get uploadButtonText => "Carregue ficheiro";
 
   @override
-  String get verifyEmailTitle => "Verify your email";
+  String get verifyEmailTitle => "Verifique o seu email";
 
   @override
   String get verificationEmailSentText =>
-      "A verification email has been sent to your email address. Please check your email and click on the link to verify your email address.";
+      "Um email de verificação foi enviado para seu email. Confira sua caixa de entrada e clique no link para verificar o seu endereço de email.";
 
   @override
   String get verificationFailedText =>
-      "We couldn't verify your email address. ";
+      "Não conseguimos verificar seu endereço de email. ";
 
   @override
-  String get resendVerificationEmailButtonLabel => "Resend verification email";
+  String get resendVerificationEmailButtonLabel =>
+      "Reenviar email de verificação";
 
   @override
-  String get verificationEmailSentTextShort => "Verification email sent";
+  String get verificationEmailSentTextShort => "Email de verificação enviado";
 
   @override
-  String get emailIsNotVerifiedText => "Email is not verified";
+  String get emailIsNotVerifiedText => "Email não está verificado";
 
   @override
   String get waitingForEmailVerificationText =>
-      "Waiting for email verification";
+      "Aguardando verificação do email";
 
   @override
-  String get dismissButtonLabel => "Dismiss";
+  String get dismissButtonLabel => "Ignorar";
 
   @override
   String get okButtonLabel => "OK";
 
   @override
   String get checkEmailHintText =>
-      "Please check your email and click the link to verify your email address.";
+      "Por favor confira sua caixa de entrada e clique no link para verificar seu endereço de email.";
 
   @override
-  String get doneButtonLabel => "Done";
+  String get doneButtonLabel => "Feito";
 
   @override
   String get invalidVerificationCodeErrorText =>
-      "The code you entered is invalid. Please try again.";
+      "O código que inseriu é inválido. Por favor tente novamente.";
 
   @override
-  String get ulinkProviderAlertTitle => "Unlink provider";
+  String get ulinkProviderAlertTitle => "Desassociar provedor";
 
   @override
-  String get confirmUnlinkButtonLabel => "Unlink";
+  String get confirmUnlinkButtonLabel => "Desassociar";
 
   @override
-  String get cancelButtonLabel => "Cancel";
+  String get cancelButtonLabel => "Cancelar";
 
   @override
   String get unlinkProviderAlertMessage =>
-      "Are you sure you want to unlink this provider?";
+      "Tem a certeza que quer desassociar este provedor?";
 
   @override
   String get weakPasswordErrorText =>
-      "Password should be at least 6 characters";
+      "A senha deve ter pelo menos 6 caracteres";
 
   @override
-  String get confirmDeleteAccountAlertTitle => "Confirm account deletion";
+  String get confirmDeleteAccountAlertTitle => "Confirmar eliminação de conta";
 
   @override
   String get confirmDeleteAccountAlertMessage =>
-      "Are you sure you want to delete your account?";
+      "Tem a certeza que quer eliminar sua conta?";
 
   @override
-  String get confirmDeleteAccountButtonLabel => "Yes, delete";
+  String get confirmDeleteAccountButtonLabel => "Sim, eliminar";
 
   @override
-  String get sendVerificationEmailLabel => "Send verification email";
+  String get sendVerificationEmailLabel => "Enviar email de verificação";
 }

--- a/packages/firebase_ui_localizations/lib/src/lang/ro.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ro.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/ru.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/ru.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/th.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/th.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/tr.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/tr.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/uk.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/uk.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/zh.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/zh.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';

--- a/packages/firebase_ui_localizations/lib/src/lang/zh_tw.dart
+++ b/packages/firebase_ui_localizations/lib/src/lang/zh_tw.dart
@@ -1,4 +1,4 @@
-// Copyright 2024, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import '../default_localizations.dart';


### PR DESCRIPTION
## Description

Many french translation values were missing.

Many files are edited because I run `dart run firebase_ui_localizations:gen_l10n`. 
`firebase_ui_fr.arb` is now well translated.
`firebase_ui_pt.arb` is now fixed.

## Related Issues

closes https://github.com/firebase/FirebaseUI-Flutter/issues/508

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
