### PR TITLE
Fix(firebase_ui_auth): Add padding between avatar and display name form

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/editable_user_display_name.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/editable_user_display_name.dart
@@ -3,9 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart' as fba;
+import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart';
 
 import '../actions.dart';
@@ -140,11 +140,14 @@ class _EditableUserDisplayNameState extends State<EditableUserDisplayName> {
         ),
       );
     } else {
-      textField = TextField(
-        autofocus: true,
-        controller: ctrl,
-        decoration: InputDecoration(hintText: l.name, labelText: l.name),
-        onSubmitted: (_) => _finishEditing(),
+      textField = Padding(
+        padding: const EdgeInsets.symmetric(vertical: 5.5),
+        child: TextField(
+          autofocus: true,
+          controller: ctrl,
+          decoration: InputDecoration(hintText: l.name, labelText: l.name),
+          onSubmitted: (_) => _finishEditing(),
+        ),
       );
     }
 


### PR DESCRIPTION
## Description

There is not padding between avatar and display name form.

## Related Issues

When user want to  custom a bit the UI, it is difficult to proceed.

![image](https://github.com/user-attachments/assets/5369fc3b-20da-45c3-9ee4-074e070e1900)

After :

![image](https://github.com/user-attachments/assets/b2704991-a8c3-4087-9eb7-1cd38edf0167)

Padding added is the same as the one used for non editing.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
