### PR TITLE
fix(firebase_ui_shared): Ensure AlertDialog works for iOS when using MaterialApp()

### DIFF
--- a/packages/firebase_ui_shared/lib/src/universal_alert.dart
+++ b/packages/firebase_ui_shared/lib/src/universal_alert.dart
@@ -51,7 +51,7 @@ class UniversalAlert extends PlatformWidget {
 
   @override
   Widget buildMaterial(BuildContext context) {
-    return AlertDialog(
+    return AlertDialog.adaptive(
       title: Text(title),
       content: Text(message),
       actions: [


### PR DESCRIPTION
## Description

Ensure that AlertDialog() works for iOS in MaterialApp() when using the default ProfileScreen() for delete confirmation.

## Related Issues

https://github.com/firebase/FirebaseUI-Flutter/issues/567

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
