### PR TITLE
chore(firebase_ui_oauth_google): upgrade google_sign_in to 7.2.0

### DIFF
--- a/packages/firebase_ui_auth/example/pubspec.yaml
+++ b/packages/firebase_ui_auth/example/pubspec.yaml
@@ -49,7 +49,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-  google_sign_in: ^6.2.1
+  google_sign_in: ^7.2.0
   http: ^1.1.2
   integration_test:
     sdk: flutter

--- a/packages/firebase_ui_oauth_google/pubspec.yaml
+++ b/packages/firebase_ui_oauth_google/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   firebase_ui_oauth: ^2.0.1
   flutter:
     sdk: flutter
-  google_sign_in: ^6.2.1
+  google_sign_in: ^7.2.0
 
 dev_dependencies:
   flutter_test:

--- a/tests/pubspec.yaml
+++ b/tests/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   cloud_firestore: ^6.1.1
   firebase_ui_firestore: ^2.0.1
   http: ^1.1.2
-  google_sign_in: ^6.2.1
+  google_sign_in: ^7.2.0
   firebase_ui_shared: ^1.4.2
   firebase_database: ^12.1.1
   firebase_ui_database: ^2.0.1


### PR DESCRIPTION
## Description

Moving the google_sign_in dependency to latest (7.2.0). Note that I have not been able to get the e2e to run on my machine.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] All unit tests pass (`melos run test:unit:all` doesn't fail).
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [] Yes, this is a breaking change.
- [X] No, this is _not_ a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/FirebaseUI-Flutter/issues
[Contributor Guide]: https://github.com/firebase/FirebaseUI-Flutter/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
